### PR TITLE
Be more resilient when running setup.py

### DIFF
--- a/news/18.bugfix
+++ b/news/18.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue with resolving certain packages which imported and executed other libraries (such as ``versioneer``) during ``setup.py`` execution.

--- a/src/requirementslib/__init__.py
+++ b/src/requirementslib/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 
 from .exceptions import RequirementError

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -236,12 +236,14 @@ class FileRequirement(BaseRequirement):
         ):
             from distutils.core import run_setup
 
+            old_curdir = os.getcwd()
             try:
+                os.chdir(str(self.setup_path.parent))
                 dist = run_setup(self.setup_path.as_posix(), stop_after="init")
                 name = dist.get_name()
             except (FileNotFoundError, IOError) as e:
                 dist = None
-            except (NameError, RuntimeError) as e:
+            except Exception as e:
                 from .._compat import InstallRequirement, make_abstract_dist
 
                 try:
@@ -257,6 +259,8 @@ class FileRequirement(BaseRequirement):
                     name = dist.project_name
                 except (TypeError, ValueError, AttributeError) as e:
                     dist = None
+            finally:
+                os.chdir(old_curdir)
         hashed_loc = hashlib.sha256(loc.encode("utf-8")).hexdigest()
         hashed_name = hashed_loc[-7:]
         if not name or name == "UNKNOWN":

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -236,7 +236,7 @@ class FileRequirement(BaseRequirement):
         ):
             from distutils.core import run_setup
 
-            old_curdir = os.getcwd()
+            old_curdir = os.path.abspath(os.getcwd())
             try:
                 os.chdir(str(self.setup_path.parent))
                 dist = run_setup(self.setup_path.as_posix(), stop_after="init")


### PR DESCRIPTION
Fix pypa/pipenv#2421, I hope.

* `chdir` to where setup.py is so we get the same behaviour as pip and plain `python setup.py`.
* Be more resilient when running setup.py. If it fails with any reason, fall back to manual requirement creation, instead of giving up.