### PR TITLE
Rely on urlparse to get the host name

### DIFF
--- a/news/22.bugfix
+++ b/news/22.bugfix
@@ -1,0 +1,1 @@
+Use ``hostname`` instead of ``netloc`` to format urls to avoid dropping usernames when they are included.

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -159,7 +159,7 @@ def prepare_pip_source_args(sources, pip_args=None):
         # Trust the host if it's not verified.
         if not sources[0].get("verify_ssl", True):
             pip_args.extend(
-                ["--trusted-host", urlparse(sources[0]["url"]).netloc.split(":")[0]]
+                ["--trusted-host", urlparse(sources[0]["url"]).hostname]
             )
         # Add additional sources as extra indexes.
         if len(sources) > 1:


### PR DESCRIPTION
This is more reliable than splitting netloc ourselves.