### PR TITLE
Unc paths

### DIFF
--- a/news/29.bugfix
+++ b/news/29.bugfix
@@ -1,0 +1,1 @@
+If a package is stored on a network share drive, we now resolve it in a way that gets the correct relative path

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -60,6 +60,19 @@ def is_vcs(pipfile_entry):
     return False
 
 
+def check_for_unc_path(path):
+    """ Checks to see if a pathlib `Path` object is a unc path or not"""
+    if (
+        os.name == "nt"
+        and len(path.drive) > 2
+        and not path.drive[0].isalpha()
+        and path.drive[1] != ":"
+    ):
+        return True
+    else:
+        return False
+
+
 def get_converted_relative_path(path, relative_to=os.curdir):
     """Convert `path` to be relative.
 
@@ -69,7 +82,7 @@ def get_converted_relative_path(path, relative_to=os.curdir):
     This performs additional conversion to ensure the result is of POSIX form,
     and starts with `./`, or is precisely `.`.
     """
-    
+
     start_path = Path(relative_to)
     try:
         start = start_path.resolve()
@@ -79,15 +92,15 @@ def get_converted_relative_path(path, relative_to=os.curdir):
     # check if there is a drive letter or mount point
     # if it is a mountpoint use the original absolute path
     # instead of the unc path
-    if (
-        os.name == "nt"
-        and len(start.drive) > 2
-        and not start.drive[0].isalpha()
-        and start.drive[1] != ":"
-    ):
+    if check_for_unc_path(start):
         start = start_path.absolute()
 
     path = start.joinpath(path).relative_to(start)
+
+    # check and see if the path that was passed into the function is a UNC path
+    # and raise value error if it is not.
+    if check_for_unc_path(path):
+        raise ValueError("The path argument does not currently accept UNC paths")
 
     relpath_s = posixpath.normpath(path.as_posix())
     if not (relpath_s == "." or relpath_s.startswith("./")):

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -69,12 +69,24 @@ def get_converted_relative_path(path, relative_to=os.curdir):
     This performs additional conversion to ensure the result is of POSIX form,
     and starts with `./`, or is precisely `.`.
     """
-    start = Path(relative_to)
+    
+    start_path = Path(relative_to)
     try:
-        start = start.resolve()
+        start = start_path.resolve()
     except OSError:
-        start = start.absolute()
-    path = start.joinpath(path).relative_to(start)
+        start = start_path.absolute()
+
+    # check if there is a drive letter or mount point
+    # if it is a mountpoint use the original absolute path
+    # instead of the unc path
+    if (
+        os.name == "nt"
+        and len(start.drive) > 2
+        and not start.drive[0].isalpha()
+        and start.drive[1] != ":"
+    ):
+        start = start_path.absolute()
+
 
     relpath_s = posixpath.normpath(path.as_posix())
     if not (relpath_s == "." or relpath_s.startswith("./")):

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -87,6 +87,7 @@ def get_converted_relative_path(path, relative_to=os.curdir):
     ):
         start = start_path.absolute()
 
+    path = start.joinpath(path).relative_to(start)
 
     relpath_s = posixpath.normpath(path.as_posix())
     if not (relpath_s == "." or relpath_s.startswith("./")):


### PR DESCRIPTION
check if there is a drive letter or mount point in resolved windows path. If it is a mount point use the original absolute path instead of the unc path.