### PR TITLE
Parse and write lockfiles, lazy imports, resolver

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,7 +26,7 @@ news = "inv news.add"
 tests = "pytest -v --ignore=src/requirementslib/_vendor/ tests"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -255,6 +255,13 @@
             "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==0.6.0"
         },
+        "prettytoml": {
+            "hashes": [
+                "sha256:c1bdadbc561c1852ca59ba406dc186281f6bf599afc9453e45a907c11be92693",
+                "sha256:e74f3c4469b66356f0ab041a00179b451c72edbbb150f21b4b60fffb2e69c2c8"
+            ],
+            "version": "==0.3"
+        },
         "prompt-toolkit": {
             "hashes": [
                 "sha256:1df952620eccb399c53ebb359cc7d9a8d3a9538cb34c5a1344bdbeb29fbcc381",
@@ -320,6 +327,12 @@
             ],
             "index": "pypi",
             "version": "==3.6.3"
+        },
+        "pytoml": {
+            "hashes": [
+                "sha256:dae3c4e31d09eb06a6076d671f2281ee5d2c43cbeae16599c3af20881bb818ac"
+            ],
+            "version": "==0.1.18"
         },
         "pytz": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b3dfa9e42dcbe57bb7fd378b2e5684609a40f0b1ce8d16b75800faa28108237b"
+            "sha256": "3477adffca072593f1479ab2ff0bb17266f3ab646e378c8a3068fe733ae87edc"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [{
             "name": "pypi",
@@ -31,10 +31,10 @@
         },
         "arpeggio": {
             "hashes": [
-                "sha256:828ea85ca3c7a99125dc83000ca170c1ea1105c75cbf67a513c2e16e05e36f67",
-                "sha256:984a53471327bbb69ed528cac98fa6d42c1676300d047fc13fada69dd5f84ce4"
+                "sha256:a5258b84f76661d558492fa87e42db634df143685a0e51802d59cae7daad8732",
+                "sha256:dc5c0541e7cc2c6033dc0338133436abfac53655624784736e9bc8bd35e56583"
             ],
-            "version": "==1.8.0"
+            "version": "==1.9.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -159,12 +159,12 @@
         },
         "invoke": {
             "hashes": [
-                "sha256:21274204515dca62206470b088bbcf9d41ffda82b3715b90e01d71b7a4681921",
-                "sha256:4a4cc031db311cbfb3fdd8ec93a06c892533c27b931f4be14b24c97cd042b14e",
-                "sha256:621b6564f992c37166e16090d7e7cccb3b922e03a58e980dfa5e543a931b652f"
+                "sha256:1db6cf918e5df10efe4d61101b19763abe1510b6b2fe8c553daba25476de8044",
+                "sha256:265eead8c89805a2ac5083200842db6da7636ac63fb4fe0d1121b930770f3e2a",
+                "sha256:3e8e2c2e69493227e210a1d19ccc7c44189240385dda4c9b8eb5d98fa0f68a3e"
             ],
             "index": "pypi",
-            "version": "==1.0.0"
+            "version": "==1.1.0"
         },
         "iso8601": {
             "hashes": [
@@ -201,6 +201,14 @@
             ],
             "version": "==0.6.1"
         },
+        "modutil": {
+            "hashes": [
+                "sha256:2c85c1666649e92e56de17c00e1e831313602d9b55e8661d39c01e39003b45f7",
+                "sha256:cc3dad264e36ed359fdd67c4588959d2996bd0402ad9c9d974ca906821537218"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
@@ -218,10 +226,10 @@
         },
         "parso": {
             "hashes": [
-                "sha256:8105449d86d858e53ce3e0044ede9dd3a395b1c9716c696af8aa3787158ab806",
-                "sha256:d250235e52e8f9fc5a80cc2a5f804c9fefd886b2e67a2b1099cf085f403f8e33"
+                "sha256:35704a43a3c113cce4de228ddb39aab374b8004f4f2407d070b6a2ca784ce8a2",
+                "sha256:895c63e93b94ac1e1690f5fdd40b65f07c8171e3e53cbd7793b5b96c0e0a7f24"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "parver": {
             "hashes": [
@@ -244,7 +252,7 @@
                 "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
                 "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==0.6.0"
         },
         "prompt-toolkit": {
@@ -269,7 +277,7 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==1.5.4"
         },
         "pycodestyle": {
@@ -307,11 +315,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:8ea01fc4fcc8e1b1e305252b4bc80a1528019ab99fd3b88666c9dc38d754406c",
-                "sha256:90898786b3d0b880b47645bae7b51aa9bbf1e9d1e4510c2cfd15dd65c70ea0cd"
+                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
+                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
             ],
             "index": "pypi",
-            "version": "==3.6.2"
+            "version": "==3.6.3"
         },
         "pytz": {
             "hashes": [
@@ -325,7 +333,7 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version >= '2.6'",
             "version": "==2.19.1"
         },
         "requests-toolbelt": {
@@ -333,7 +341,7 @@
                 "sha256:42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237",
                 "sha256:f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version >= '2.6'",
             "version": "==0.8.0"
         },
         "requirements-parser": {
@@ -370,11 +378,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:85f7e32c8ef07f4ba5aeca728e0f7717bef0789fba8458b8d9c5c294cad134f3",
-                "sha256:d45480a229edf70d84ca9fae3784162b1bc75ee47e480ffe04a4b7f21a95d76d"
+                "sha256:217ad9ece2156ed9f8af12b5d2c82a499ddf2c70a33c5f81864a08d8c67b9efc",
+                "sha256:a765c6db1e5b62aae857697cd4402a5c1a315a7b0854bbcd0fc8cdc524da5896"
             ],
             "index": "pypi",
-            "version": "==1.7.5"
+            "version": "==1.7.6"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -388,7 +396,7 @@
                 "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
                 "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
             ],
-            "markers": "python_version != '3.3.*' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*'",
             "version": "==1.1.0"
         },
         "strict-rfc3339": {
@@ -411,18 +419,18 @@
         },
         "towncrier": {
             "hashes": [
-                "sha256:2f3797a603c889dfd9102113d7438fccedf500c6ebb5953b681117395e54923b",
-                "sha256:54e9106061bad0425b62d0bf264ef3b6a443e8afd50f903f11f387a089b80204"
+                "sha256:3c0da1de042861df9030c0608d346d55cabe14cfa7cf04045f22b0af63eb8aa7",
+                "sha256:cfde66ada782db9269407eaefb38562d3d2a4bc4d7647c0b2197ed184b869aae"
             ],
             "index": "pypi",
-            "version": "==18.6.0rc1"
+            "version": "==18.6.0"
         },
         "tqdm": {
             "hashes": [
                 "sha256:224291ee0d8c52d91b037fd90806f48c79bcd9994d3b0abc9e44b946a908fccd",
                 "sha256:77b8424d41b31e68f437c6dd9cd567aebc9a860507cb42fbd880a5f822d966fe"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version != '3.0.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.1.*' and python_version >= '2.6'",
             "version": "==4.23.4"
         },
         "twine": {
@@ -438,7 +446,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.3.*' and python_version != '3.0.*' and python_version < '4' and python_version != '3.1.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version < '4' and python_version >= '2.6'",
             "version": "==1.23"
         },
         "wcwidth": {

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ install_requires = [
     "distlib",
     "first",
     "six",
-    'pathlib2==2.1.0; python_version<"3.4"',
+    'pathlib2; python_version<"3.4"',
     "requirements-parser",
     "toml",
     "contoml",

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,11 @@ install_requires = [
     "first",
     "six",
     'pathlib2; python_version<"3.4"',
+    'backports.weakref; python_version<"3.4"',
     "requirements-parser",
     "toml",
     "contoml",
+    "prettytoml",
     "modutil",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -14,50 +14,49 @@ here = os.path.abspath(os.path.dirname(__file__))
 def read(*parts):
     # intentionally *not* adding an encoding option to open, See:
     #   https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
-    with codecs.open(os.path.join(here, *parts), 'r') as fp:
+    with codecs.open(os.path.join(here, *parts), "r") as fp:
         return fp.read()
 
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
+
 
 if sys.argv[-1] == "publish":
     os.system("python setup.py sdist bdist_wheel upload")
     sys.exit()
 
-long_description = read('README.rst')
+long_description = read("README.rst")
 
-tests_require = [
-    'pytest',
-    'pytest-xdist',
-]
+tests_require = ["pytest", "pytest-xdist"]
 install_requires = [
-    'attrs',
-    'packaging',
-    'distlib',
-    'first',
-    'six',
+    "attrs",
+    "packaging",
+    "distlib",
+    "first",
+    "six",
     'pathlib2==2.1.0; python_version<"3.4"',
-    'requirements-parser',
-    'toml',
-    'contoml',
+    "requirements-parser",
+    "toml",
+    "contoml",
+    "modutil",
 ]
 
 
 class UploadCommand(Command):
     """Support setup.py publish."""
-    description = 'Build and publish the package.'
+
+    description = "Build and publish the package."
     user_options = []
 
     @staticmethod
     def status(s):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
+        print("\033[1m{0}\033[0m".format(s))
 
     def initialize_options(self):
         pass
@@ -68,11 +67,13 @@ class UploadCommand(Command):
     def run(self):
         # self.status('Building Source distribution…')
         # os.system('{0} setup.py sdist'.format(sys.executable))
-        self.status('Uploading the package to PyPi via Twine...')
-        os.system('twine upload dist/*')
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(find_version("src", "requirementslib", "__init__.py")))
-        os.system('git push origin --tags')
+        self.status("Uploading the package to PyPi via Twine...")
+        os.system("twine upload dist/*")
+        self.status("Pushing git tags…")
+        os.system(
+            "git tag v{0}".format(find_version("src", "requirementslib", "__init__.py"))
+        )
+        os.system("git push origin --tags")
         sys.exit()
 
 
@@ -94,28 +95,20 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy"
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    keywords='pipfile requirements.txt pip requirementslib',
-    author='Dan Ryan',
-    author_email='dan@danryan.co',
-    url='https://github.com/sarugaku/requirementslib',
-    license='MIT',
+    keywords="pipfile requirements.txt pip requirementslib",
+    author="Dan Ryan",
+    author_email="dan@danryan.co",
+    url="https://github.com/sarugaku/requirementslib",
+    license="MIT",
     package_dir={"": "src"},
-    packages=find_packages(
-        where="src",
-        exclude=["docs", "tests*", "tasks"],
-    ),
-    package_data={
-        '': ['LICENSE'],
-        "src._vendor.pipfile": ["LICENSE.*"],
-    },
+    packages=find_packages(where="src", exclude=["docs*", "tests*", "tasks*"]),
+    package_data={"": ["LICENSE"], "src._vendor.pipfile": ["LICENSE.*"]},
     entry_points={},
     tests_require=tests_require,
     zip_safe=False,
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
     install_requires=install_requires,
-    extras_require={
-        'testing': tests_require,
-    },
+    extras_require={"testing": tests_require},
 )

--- a/src/requirementslib/_compat.py
+++ b/src/requirementslib/_compat.py
@@ -1,45 +1,79 @@
 # -*- coding=utf-8 -*-
-import importlib
+import functools
+import io
+import modutil
+import os
 import six
+import sys
+import warnings
+from first import first
+from shutil import rmtree
+from tempfile import _bin_openflags, gettempdir, _mkstemp_inner, mkdtemp
+
+try:
+    from tempfile import _infer_return_type
+except ImportError:
+
+    def _infer_return_type(*args):
+        _types = set()
+        for arg in args:
+            if isinstance(type(arg), six.string_types):
+                _types.add(str)
+            elif isinstance(type(arg), bytes):
+                _types.add(bytes)
+            elif arg:
+                _types.add(type(arg))
+        return _types.pop()
+
+
+if sys.version_info[:2] >= (3, 5):
+    try:
+        from pathlib import Path
+    except ImportError:
+        from pathlib2 import Path
+
+try:
+    from weakref import finalize
+except ImportError:
+    from backports.weakref import finalize
 
 # Use these imports as compatibility imports
-try:
-    from pathlib import Path
-except ImportError:
+if six.PY3:
+    class FileNotFoundError(FileNotFoundError):
+        pass
+
+else:
     from pathlib2 import Path
+
+    class FileNotFoundError(IOError):
+        pass
+
+    class ResourceWarning(Warning):
+        pass
+
 
 try:
     from urllib.parse import urlparse, unquote
 except ImportError:
     from urlparse import urlparse, unquote
 
-if six.PY2:
-
-    class FileNotFoundError(IOError):
-        pass
-
-
-else:
-
-    class FileNotFoundError(FileNotFoundError):
-        pass
-
 
 def do_import(module_path, subimport=None, old_path=None):
-    internal = "pip._internal.{0}".format(module_path)
     old_path = old_path or module_path
+    internal = "pip._internal.{0}".format(module_path)
     pip9 = "pip.{0}".format(old_path)
-    try:
-        _tmp = importlib.import_module(internal)
-    except ImportError:
-        _tmp = importlib.import_module(pip9)
+    mod, imp_getattr = modutil.lazy_import(__name__, {internal,})
+    mod, old_getattr = modutil.lazy_import(__name__, {pip9,})
+    chained = modutil.chained___getattr__(__name__, imp_getattr, old_getattr,)
+    package = module_path.rsplit(".", 1)[-1]
+    imported = chained(package)
     if subimport:
-        return getattr(_tmp, subimport, _tmp)
-    return _tmp
+        return getattr(imported, subimport)
+    return imported
 
 
 InstallRequirement = do_import("req.req_install", "InstallRequirement")
-user_cache_dir = do_import("utils.appdirs", "user_cache_dir")
+USER_CACHE_DIR = do_import("locations", "USER_CACHE_DIR")
 FAVORITE_HASH = do_import("utils.hashes", "FAVORITE_HASH")
 is_file_url = do_import("download", "is_file_url")
 url_to_path = do_import("download", "url_to_path")
@@ -48,9 +82,229 @@ is_archive_file = do_import("download", "is_archive_file")
 _strip_extras = do_import("req.req_install", "_strip_extras")
 Link = do_import("index", "Link")
 Wheel = do_import("wheel", "Wheel")
-is_installable_file = do_import("utils.misc", "is_installable_file", old_path="utils")
 is_installable_dir = do_import("utils.misc", "is_installable_dir", old_path="utils")
 make_abstract_dist = do_import(
     "operations.prepare", "make_abstract_dist", old_path="req.req_set"
 )
 VcsSupport = do_import("vcs", "VcsSupport")
+RequirementPreparer = do_import("operations.prepare", "RequirementPreparer")
+Resolver = do_import("resolve", "Resolver")
+RequirementSet = do_import("req.req_set", "RequirementSet")
+PackageFinder = do_import("index", "PackageFinder")
+WheelCache = do_import("cache", "WheelCache")
+Command = do_import("basecommand", "Command")
+cmdoptions = do_import("cmdoptions")
+
+
+class TemporaryDirectory(object):
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.  For
+    example:
+
+        with TemporaryDirectory() as tmpdir:
+            ...
+
+    Upon exiting the context, the directory and everything contained
+    in it are removed.
+    """
+
+    def __init__(self, suffix=None, prefix=None, dir=None):
+        self.name = mkdtemp(suffix, prefix, dir)
+        self._finalizer = finalize(
+            self,
+            self._cleanup,
+            self.name,
+            warn_message="Implicitly cleaning up {!r}".format(self),
+        )
+
+    @classmethod
+    def _cleanup(cls, name, warn_message):
+        rmtree(name)
+        warnings.warn(warn_message, ResourceWarning)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def cleanup(self):
+        if self._finalizer.detach():
+            rmtree(self.name)
+
+
+def _sanitize_params(prefix, suffix, dir):
+    """Common parameter processing for most APIs in this module."""
+    output_type = _infer_return_type(prefix, suffix, dir)
+    if suffix is None:
+        suffix = output_type()
+    if prefix is None:
+        if output_type is str:
+            prefix = "tmp"
+        else:
+            prefix = os.fsencode("tmp")
+    if dir is None:
+        if output_type is str:
+            dir = gettempdir()
+        else:
+            dir = os.fsencode(gettempdir())
+    return prefix, suffix, dir, output_type
+
+
+class _TemporaryFileCloser:
+    """A separate object allowing proper closing of a temporary file's
+    underlying file object, without adding a __del__ method to the
+    temporary file."""
+
+    file = None  # Set here since __del__ checks it
+    close_called = False
+
+    def __init__(self, file, name, delete=True):
+        self.file = file
+        self.name = name
+        self.delete = delete
+
+    # NT provides delete-on-close as a primitive, so we don't need
+    # the wrapper to do anything special.  We still use it so that
+    # file.name is useful (i.e. not "(fdopen)") with NamedTemporaryFile.
+    if os.name != "nt":
+
+        # Cache the unlinker so we don't get spurious errors at
+        # shutdown when the module-level "os" is None'd out.  Note
+        # that this must be referenced as self.unlink, because the
+        # name TemporaryFileWrapper may also get None'd out before
+        # __del__ is called.
+
+        def close(self, unlink=os.unlink):
+            if not self.close_called and self.file is not None:
+                self.close_called = True
+                try:
+                    self.file.close()
+                finally:
+                    if self.delete:
+                        unlink(self.name)
+
+        # Need to ensure the file is deleted on __del__
+        def __del__(self):
+            self.close()
+
+    else:
+        def close(self):
+            if not self.close_called:
+                self.close_called = True
+                self.file.close()
+
+
+class _TemporaryFileWrapper:
+    """Temporary file wrapper
+    This class provides a wrapper around files opened for
+    temporary use.  In particular, it seeks to automatically
+    remove the file when it is no longer needed.
+    """
+
+    def __init__(self, file, name, delete=True):
+        self.file = file
+        self.name = name
+        self.delete = delete
+        self._closer = _TemporaryFileCloser(file, name, delete)
+
+    def __getattr__(self, name):
+        # Attribute lookups are delegated to the underlying file
+        # and cached for non-numeric results
+        # (i.e. methods are cached, closed and friends are not)
+        file = self.__dict__["file"]
+        a = getattr(file, name)
+        if hasattr(a, "__call__"):
+            func = a
+
+            @functools.wraps(func)
+            def func_wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            # Avoid closing the file as long as the wrapper is alive,
+            # see issue #18879.
+            func_wrapper._closer = self._closer
+            a = func_wrapper
+        if not isinstance(a, int):
+            setattr(self, name, a)
+        return a
+
+    # The underlying __enter__ method returns the wrong object
+    # (self.file) so override it to return the wrapper
+
+    def __enter__(self):
+        self.file.__enter__()
+        return self
+
+    # Need to trap __exit__ as well to ensure the file gets
+    # deleted when used in a with statement
+
+    def __exit__(self, exc, value, tb):
+        result = self.file.__exit__(exc, value, tb)
+        self.close()
+        return result
+
+    def close(self):
+        """
+        Close the temporary file, possibly deleting it.
+        """
+        self._closer.close()
+
+    # iter() doesn't use __getattr__ to find the __iter__ method
+
+    def __iter__(self):
+        # Don't return iter(self.file), but yield from it to avoid closing
+        # file as long as it's being used as iterator (see issue #23700).  We
+        # can't use 'yield from' here because iter(file) returns the file
+        # object itself, which has a close method, and thus the file would get
+        # closed when the generator is finalized, due to PEP380 semantics.
+        for line in self.file:
+            yield line
+
+
+def NamedTemporaryFile(
+    mode="w+b",
+    buffering=-1,
+    encoding=None,
+    newline=None,
+    suffix=None,
+    prefix=None,
+    dir=None,
+    delete=True,
+):
+    """Create and return a temporary file.
+    Arguments:
+    'prefix', 'suffix', 'dir' -- as for mkstemp.
+    'mode' -- the mode argument to io.open (default "w+b").
+    'buffering' -- the buffer size argument to io.open (default -1).
+    'encoding' -- the encoding argument to io.open (default None)
+    'newline' -- the newline argument to io.open (default None)
+    'delete' -- whether the file is deleted on close (default True).
+    The file is created as mkstemp() would do it.
+    Returns an object with a file-like interface; the name of the file
+    is accessible as its 'name' attribute.  The file will be automatically
+    deleted when it is closed unless the 'delete' argument is set to False.
+    """
+    prefix, suffix, dir, output_type = _sanitize_params(prefix, suffix, dir)
+    flags = _bin_openflags
+    # Setting O_TEMPORARY in the flags causes the OS to delete
+    # the file when it is closed.  This is only supported by Windows.
+    if os.name == "nt" and delete:
+        flags |= os.O_TEMPORARY
+    if sys.version_info < (3, 5):
+        (fd, name) = _mkstemp_inner(dir, prefix, suffix, flags)
+    else:
+        (fd, name) = _mkstemp_inner(dir, prefix, suffix, flags, output_type)
+    try:
+        file = io.open(
+            fd, mode, buffering=buffering, newline=newline, encoding=encoding
+        )
+        return _TemporaryFileWrapper(file, name, delete)
+
+    except BaseException:
+        os.unlink(name)
+        os.close(fd)
+        raise

--- a/src/requirementslib/models/dependency.py
+++ b/src/requirementslib/models/dependency.py
@@ -1,0 +1,61 @@
+# -*- coding=utf-8 -*-
+from .._compat import RequirementPreparer, Resolver, WheelCache, RequirementSet, PackageFinder, TemporaryDirectory
+from ..utils import fs_str, prepare_pip_source_args, get_pip_command, prepare_pip_source_args
+import os
+try:
+    from pipenv.environments import PIPENV_CACHE_DIR as CACHE_DIR
+except ImportError:
+    from .._compat import USER_CACHE_DIR as CACHE_DIR
+
+DOWNLOAD_DIR = fs_str(os.path.join(CACHE_DIR, 'pkgs'))
+WHEEL_DOWNLOAD_DIR = fs_str(os.path.join(CACHE_DIR, 'wheels'))
+
+
+def get_dependencies(dep, sources=None):
+    pip_command = get_pip_command()
+    if not sources:
+        sources = [{'url': 'https://pypi.org/simple', 'name': 'pypi', 'verify_ssl': True},]
+    pip_args = []
+    pip_args = prepare_pip_source_args(sources, pip_args)
+    pip_options, _ = pip_command.parser.parse_args(pip_args)
+    pip_options.cache_dir = CACHE_DIR
+    session = pip_command._build_session(pip_options)
+    wheel_cache = WheelCache(CACHE_DIR, pip_options.format_control)
+    finder = PackageFinder(
+        find_links=[],
+        index_urls=[s.get('url') for s in sources],
+        trusted_hosts=[],
+        allow_all_prereleases=True,
+        session=session,
+    )
+    download_dir = DOWNLOAD_DIR
+    _build_dir = TemporaryDirectory(fs_str('build'))
+    _source_dir = TemporaryDirectory(fs_str('source'))
+    preparer = RequirementPreparer(
+        build_dir=_build_dir.name,
+        src_dir=_source_dir.name,
+        download_dir=download_dir,
+        wheel_download_dir=WHEEL_DOWNLOAD_DIR,
+        progress_bar='off',
+        build_isolation=True
+    )
+    reqset = RequirementSet()
+    dep.is_direct = True
+    reqset.add_requirement(dep)
+    resolver = Resolver(
+        preparer=preparer,
+        finder=finder,
+        session=session,
+        upgrade_strategy="to-satisfy-only",
+        force_reinstall=True,
+        ignore_dependencies=False,
+        ignore_requires_python=True,
+        ignore_installed=True,
+        isolated=True,
+        wheel_cache=wheel_cache,
+        use_user_site=False,
+    )
+    resolver.resolve(reqset)
+    requirements = reqset.requirements.values()
+    reqset.cleanup_files()
+    return requirements

--- a/src/requirementslib/models/lockfile.py
+++ b/src/requirementslib/models/lockfile.py
@@ -2,23 +2,83 @@
 from __future__ import absolute_import
 import attr
 import json
+import os
+import six
 from .requirements import Requirement
+from .pipfile import Source, Hash, RequiresSection
 from .utils import optional_instance_of
+from ..utils import atomic_open_for_write
 from .._compat import Path, FileNotFoundError
+
+
+DEFAULT_NEWLINES = u"\n"
+
+
+def preferred_newlines(f):
+    if isinstance(f.newlines, six.text_type):
+        return f.newlines
+    return DEFAULT_NEWLINES
+
+
+class _LockFileEncoder(json.JSONEncoder):
+    """A specilized JSON encoder to convert loaded TOML data into a lock file.
+
+    This adds a few characteristics to the encoder:
+
+    * The JSON is always prettified with indents and spaces.
+    * PrettyTOML's container elements are seamlessly encodable.
+    * The output is always UTF-8-encoded text, never binary, even on Python 2.
+    """
+
+    def __init__(self, newlines=None):
+        self.newlines = DEFAULT_NEWLINES if not newlines else newlines
+        super(_LockFileEncoder, self).__init__(
+            indent=4, separators=(",", ": "), sort_keys=True
+        )
+
+    def default(self, obj):
+        from prettytoml.elements.common import ContainerElement, TokenElement
+
+        if isinstance(obj, (ContainerElement, TokenElement)):
+            return obj.primitive_value
+        return super(_LockFileEncoder, self).default(obj)
+
+    def encode(self, obj):
+        content = super(_LockFileEncoder, self).encode(obj)
+        if not isinstance(content, six.text_type):
+            content = content.decode("utf-8")
+        return content
 
 
 @attr.s
 class Lockfile(object):
     dev_requirements = attr.ib(default=attr.Factory(list))
     requirements = attr.ib(default=attr.Factory(list))
+    sources = attr.ib(default=attr.Factory(list))
     path = attr.ib(default=None, validator=optional_instance_of(Path))
-    pipfile_hash = attr.ib(default=None)
+    pipfile_hash = attr.ib(default=None, validator=optional_instance_of(Hash))
+    encoder = attr.ib(default=None, validator=optional_instance_of(_LockFileEncoder))
+    pipfile_spec = attr.ib(default=6, converter=int)
+    requires = attr.ib(default=None, validator=optional_instance_of(RequiresSection))
+
+    @classmethod
+    def load(cls, path=None):
+        if not path:
+            path = os.curdir
+        path = Path(path).absolute()
+        if path.is_dir():
+            path = path / "Pipfile.lock"
+        elif path.name == "Pipfile":
+            path = path.parent / "Pipfile.lock"
+        if not path.exists():
+            raise OSError("Path does not exist: %s" % path)
+        return cls.create(path.parent, lockfile_name=path.name)
 
     @classmethod
     def create(cls, project_path, lockfile_name="Pipfile.lock"):
         """Create a new lockfile instance
 
-        :param project_path: Path to the project root
+        :param project_path: Path to  project root
         :type project_path: str or :class:`~pathlib.Path`
         :returns: List[:class:`~requirementslib.Requirement`] objects
         """
@@ -28,20 +88,88 @@ class Lockfile(object):
         lockfile_path = project_path / lockfile_name
         requirements = []
         dev_requirements = []
+        sources = []
+        pipfile_hash = None
         if not lockfile_path.exists():
             raise FileNotFoundError("No such lockfile: %s" % lockfile_path)
 
         with lockfile_path.open(encoding="utf-8") as f:
-            lockfile = json.loads(f.read())
+            lockfile = json.load(f)
+            encoder = _LockFileEncoder(newlines=preferred_newlines(f))
         for k in lockfile["develop"].keys():
             dev_requirements.append(Requirement.from_pipfile(k, lockfile["develop"][k]))
         for k in lockfile["default"].keys():
             requirements.append(Requirement.from_pipfile(k, lockfile["default"][k]))
+        meta = lockfile["_meta"]
+        pipfile_hash = Hash.create(**meta.get("hash")) if "hash" in meta else None
+        pipfile_spec = meta.get("pipfile-spec", 6)
+        requires = None
+        if "requires" in meta:
+            requires = RequiresSection.create(**meta.get("requires"))
+        for source in meta.get("sources", []):
+            sources.append(
+                Source(
+                    url=source.get("url"),
+                    verify_ssl=source.get("verify_ssl", True),
+                    name=source.get("name"),
+                )
+            )
+
         return cls(
             path=lockfile_path,
             requirements=requirements,
             dev_requirements=dev_requirements,
+            encoder=encoder,
+            sources=sources,
+            pipfile_hash=pipfile_hash,
+            pipfile_spec=pipfile_spec,
+            requires=requires,
         )
+
+    @property
+    def dev_requirements_list(self):
+        return [r.as_pipfile() for r in self.dev_requirements]
+
+    @property
+    def requirements_list(self):
+        return [r.as_pipfile() for r in self.requirements]
+
+    @property
+    def meta(self):
+        return_dict = {"pipfile-spec": self.pipfile_spec}
+        if self.sources:
+            return_dict["sources"] = [s.get_dict() for s in self.sources]
+        if self.pipfile_hash:
+            return_dict["hash"] = self.pipfile_hash.get_dict()
+        if self.requires:
+            return_dict["requires"] = self.requires.get_dict()
+        return return_dict
+
+    def as_dict(self):
+        return_dict = {
+            "_meta": self.meta,
+            "develop": {
+                pkg: entry
+                for req in self.dev_requirements_list
+                for pkg, entry in req.items
+            },
+            "default": {
+                pkg: entry for req in self.requirements_list for pkg, entry in req.items
+            },
+        }
+        return return_dict
+
+    def write(self):
+        if not self.encoder:
+            self.encoder = _LockFileEncoder(newlines=DEFAULT_NEWLINES)
+        s = self.encoder.encode(self.as_dict())
+        open_kwargs = {"newline": self.encoder.newlines, "encoding": "utf-8"}
+        with atomic_open_for_write(self.lockfile_path.as_posix(), **open_kwargs) as f:
+            f.write(s)
+            # Write newline at end of document. GH-319.
+            # Only need '\n' here; the file object handles the rest.
+            if not s.endswith(u"\n"):
+                f.write(u"\n")
 
     def as_requirements(self, include_hashes=False, dev=False):
         """Returns a list of requirements in pip-style format"""

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -11,6 +11,7 @@ from first import first
 from six.moves.urllib import parse as urllib_parse
 
 from .baserequirement import BaseRequirement
+from .dependency import get_dependencies
 from .markers import PipenvMarkers
 from .utils import (
     HASH_STRING,
@@ -870,3 +871,8 @@ class Requirement(object):
             else:
                 self._ireq = InstallRequirement.from_line(ireq_line)
         return self._ireq
+
+    def get_dependencies(self, sources=None):
+        if not sources:
+            sources = [{'url': 'https://pypi.org/simple', 'name': 'pypi', 'verify_ssl': True},]
+        return get_dependencies(self.ireq, sources)

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -4,8 +4,11 @@ import logging
 import os
 import posixpath
 import six
-
+import stat
+import sys
+from contextlib import contextmanager
 from itertools import product
+from ._compat import Command, cmdoptions
 
 try:
     from urllib.parse import urlparse
@@ -197,3 +200,87 @@ def prepare_pip_source_args(sources, pip_args=None):
                         ["--trusted-host", urlparse(source["url"]).hostname]
                     )
     return pip_args
+
+
+@contextmanager
+def atomic_open_for_write(target, binary=False, newline=None, encoding=None):
+    """Atomically open `target` for writing.
+
+    This is based on Lektor's `atomic_open()` utility, but simplified a lot
+    to handle only writing, and skip many multi-process/thread edge cases
+    handled by Werkzeug.
+
+    How this works:
+
+    * Create a temp file (in the same directory of the actual target), and
+      yield for surrounding code to write to it.
+    * If some thing goes wrong, try to remove the temp file. The actual target
+      is not touched whatsoever.
+    * If everything goes well, close the temp file, and replace the actual
+      target with this new file.
+    """
+    from ._compat import NamedTemporaryFile
+
+    mode = "w+b" if binary else "w"
+    f = NamedTemporaryFile(
+        dir=os.path.dirname(target),
+        prefix=".__atomic-write",
+        mode=mode,
+        encoding=encoding,
+        newline=newline,
+        delete=False,
+    )
+    # set permissions to 0644
+    os.chmod(f.name, stat.S_IWUSR | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    try:
+        yield f
+    except BaseException:
+        f.close()
+        try:
+            os.remove(f.name)
+        except OSError:
+            pass
+        raise
+    else:
+        f.close()
+        try:
+            os.remove(target)  # This is needed on Windows.
+        except OSError:
+            pass
+        os.rename(f.name, target)  # No os.replace() on Python 2.
+
+
+def fs_str(string):
+    """Encodes a string into the proper filesystem encoding
+
+    Borrowed from pip-tools
+    """
+    if isinstance(string, str):
+        return string
+    assert not isinstance(string, bytes)
+    return string.encode(_fs_encoding)
+
+
+_fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+
+
+class PipCommand(Command):
+    name = 'PipCommand'
+
+
+def get_pip_command():
+    # Use pip's parser for pip.conf management and defaults.
+    # General options (find_links, index_url, extra_index_url, trusted_host,
+    # and pre) are defered to pip.
+    import optparse
+    pip_command = PipCommand()
+    pip_command.parser.add_option(cmdoptions.no_binary())
+    pip_command.parser.add_option(cmdoptions.only_binary())
+    index_opts = cmdoptions.make_option_group(
+        cmdoptions.index_group,
+        pip_command.parser,
+    )
+    pip_command.parser.insert_option_group(0, index_opts)
+    pip_command.parser.add_option(optparse.Option('--pre', action='store_true', default=False))
+
+    return pip_command


### PR DESCRIPTION
Add support for lockfile parsing and writing

- Added dependency tree building for root nodes
- Backported some utility functions
- Added lazy imports for all pip imports
- Always add fallbacks using `modutil.chain___getattr`

Signed-off-by: Dan Ryan <dan@danryan.co>
