### PR TITLE
Add extras for the constraint line for VCS

### DIFF
--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -678,7 +678,7 @@ class Requirement(object):
     @property
     def extras_as_pip(self):
         if self.extras:
-            return "[{0}]".format(",".join(self.extras))
+            return "[{0}]".format(",".join(sorted(self.extras)))
 
         return ""
 
@@ -795,7 +795,7 @@ class Requirement(object):
             args["hashes"] = _pipfile.get("hashes", [pipfile.get("hash")])
         return cls(**args)
 
-    def as_line(self, sources=None):
+    def as_line(self, sources=None, force_extras=False):
         """Format this requirement as a line in requirements.txt.
 
         If `sources` provided, it should be an sequence of mappings, containing
@@ -806,7 +806,7 @@ class Requirement(object):
         """
         line = "{0}{1}{2}{3}{4}".format(
             self.req.line_part,
-            self.extras_as_pip if not self.is_vcs else "",
+            self.extras_as_pip if force_extras or not self.is_vcs else "",
             self.specifiers if self.specifiers else "",
             self.markers_as_pip,
             self.hashes_as_pip,
@@ -822,7 +822,7 @@ class Requirement(object):
 
     @property
     def constraint_line(self):
-        return self.as_line()
+        return self.as_line(force_extras=True)
 
     def as_pipfile(self):
         good_keys = (

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -198,6 +198,12 @@ def test_get_requirements():
     # Test regression where VCS uris were being handled as paths rather than VCS entries
     assert git_reformat.vcs == 'git'
     assert git_reformat.link.url == 'git+ssh://git@github.com/pypa/pipenv.git#egg=pipenv'
+    # Test VCS requirements being added with extras for constraint_line
+    git_extras = Requirement.from_line(
+        '-e git+https://github.com/requests/requests.git@master#egg=requests[security]'
+    )
+    assert git_extras.as_line() == '-e git+https://github.com/requests/requests.git@master#egg=requests'
+    assert git_extras.constraint_line == '-e git+https://github.com/requests/requests.git@master#egg=requests[security]'
     # these will fail due to not being real paths
     # local_wheel = Requirement.from_pipfile('six', {'path': '../wheels/six/six-1.11.0-py2.py3-none-any.whl'})
     # assert local_wheel.as_line() == 'file:///home/hawk/git/wheels/six/six-1.11.0-py2.py3-none-any.whl'


### PR DESCRIPTION
Currently, `as_line()` ignores `extras` for VCS requirements. This works fine except when the constraints are needed for resolving dependencies, in which case the extras are needed.

Fixes: [pipenv issue 2725](https://github.com/pypa/pipenv/issues/2725)