### PR TITLE
Add whitespace before markers to make editable package can be installed by pip

### DIFF
--- a/news/70.bugfix
+++ b/news/70.bugfix
@@ -1,0 +1,1 @@
+Add space before environment markers ; to make editable packages can be installed by pip

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -760,7 +760,7 @@ class Requirement(object):
     @property
     def markers_as_pip(self):
         if self.markers:
-            return "; {0}".format(self.markers).replace('"', "'")
+            return " ; {0}".format(self.markers).replace('"', "'")
 
         return ""
 


### PR DESCRIPTION
Fixed https://github.com/sarugaku/requirementslib/issues/70