### PR TITLE
Dont canonicalize named requirement lines

### DIFF
--- a/news/79.bugfix
+++ b/news/79.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in named requirement normalization which caused querying the index to fail when looking up requirements with dots in their names.

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -96,7 +96,10 @@ class NamedRequirement(BaseRequirement):
 
     @property
     def line_part(self):
-        return "{0}".format(canonicalize_name(self.name))
+        # FIXME: This should actually be canonicalized but for now we have to
+        # simply lowercase it and replace underscores, since full canonicalization
+        # also replaces dots and that doesn't actually work when querying the index
+        return "{0}".format(self.name.lower().replace("_", "-"))
 
     @property
     def pipfile_part(self):


### PR DESCRIPTION
- Instead, lowercase them and replace `_` with `-`
- Fixes #79

Signed-off-by: Dan Ryan <dan@danryan.co>