### PR TITLE
Fix VCS repository acquisition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+CHANGELOG.md
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/news/89.bugfix.rst
+++ b/news/89.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which prevented mercurial repositories from acquiring commit hashes successfully.

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -585,7 +585,7 @@ class VCSRequirement(FileRequirement):
     def get_vcs_repo(self, src_dir=None):
         from .vcs import VCSRepository
         checkout_dir = self.get_checkout_dir(src_dir=src_dir)
-        url = "{0}#egg={1}".format(self.vcs_uri, self.name)
+        url = "{0}#egg={1}".format(self.link.url_without_fragment, self.name)
         vcsrepo = VCSRepository(
             url=url,
             name=self.name,
@@ -616,11 +616,10 @@ class VCSRequirement(FileRequirement):
 
     @contextmanager
     def locked_vcs_repo(self, src_dir=None):
+        if not src_dir:
+            src_dir = create_tracked_tempdir(prefix="requirementslib-", suffix="-src")
         vcsrepo = self.get_vcs_repo(src_dir=src_dir)
-        if self.ref and not self.is_local:
-            vcsrepo.checkout_ref(self.ref)
-        self.ref = self.get_commit_hash()
-        self.req.revision = self.ref
+        self.req.revision = vcsrepo.get_commit_hash()
 
         # Remove potential ref in the end of uri after ref is parsed
         if "@" in self.link.show_url and "@" in self.uri:

--- a/src/requirementslib/models/vcs.py
+++ b/src/requirementslib/models/vcs.py
@@ -31,35 +31,31 @@ class VCSRepository(object):
         return url.startswith("file")
 
     def obtain(self):
-        if not os.path.exists(self.checkout_directory):
+        if (os.path.exists(self.checkout_directory) and not
+                    self.repo_instance.is_repository_directory(self.checkout_directory)):
+            self.repo_instance.unpack(self.checkout_directory)
+        elif not os.path.exists(self.checkout_directory):
             self.repo_instance.obtain(self.checkout_directory)
-        if self.ref:
-            self.checkout_ref(self.ref)
-            self.commit_sha = self.get_commit_hash(self.ref)
         else:
-            if not self.commit_sha:
-                self.commit_sha = self.get_commit_hash()
+            if self.ref:
+                self.checkout_ref(self.ref)
+        if not self.commit_sha:
+            self.commit_sha = self.get_commit_hash()
 
     def checkout_ref(self, ref):
         if not self.repo_instance.is_commit_id_equal(
-            self.checkout_directory, self.get_commit_hash(ref)
+            self.checkout_directory, self.get_commit_hash()
         ) and not self.repo_instance.is_commit_id_equal(self.checkout_directory, ref):
             if not self.is_local:
                 self.update(ref)
 
     def update(self, ref):
         target_ref = self.repo_instance.make_rev_options(ref)
-        sha = self.repo_instance.get_revision_sha(self.checkout_directory, target_ref.arg_rev)
-        target_rev = target_ref.make_new(sha)
         if parse_version(pip_version) > parse_version("18.0"):
             self.repo_instance.update(self.checkout_directory, self.url, target_ref)
         else:
             self.repo_instance.update(self.checkout_directory, target_ref)
-        self.commit_hash = self.get_commit_hash(ref)
+        self.commit_sha = self.get_commit_hash()
 
     def get_commit_hash(self, ref=None):
-        if ref:
-            target_ref = self.repo_instance.make_rev_options(ref)
-            return self.repo_instance.get_revision_sha(self.checkout_directory, target_ref.arg_rev)
-            # return self.repo_instance.get_revision(self.checkout_directory)
         return self.repo_instance.get_revision(self.checkout_directory)


### PR DESCRIPTION
- Don't call `get_revision_sha` directly
- Include revision or ref in the url when obtaining
- Use `get_revision` as the generic approach to get a hash
- Fixes #89

Signed-off-by: Dan Ryan <dan@danryan.co>