### PR TITLE
Remove python-toml from requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ install_requires =
     setuptools>=36.2.2
     six
     tomlkit
-    toml
     vistir[spinner]>=0.2.0
 
 [options.extras_require]

--- a/tasks/news.py
+++ b/tasks/news.py
@@ -1,6 +1,6 @@
 # -*- coding=utf-8 -*-
 import invoke
-import toml
+import tomlkit
 import uuid
 from pathlib import Path
 
@@ -23,8 +23,8 @@ def get_random():
 
 @invoke.task
 def add(ctx, description, type_='feature', issue=None):
-    toml_file = get_toml_file(ctx)
-    tf = toml.load(toml_file.as_posix())
+    with get_toml_file(ctx).open() as f:
+        tf = tomlkit.parse(f.read_text())
     allowed_types = tf.get('tool', {}).get('towncrier', {}).get('type', [])
     if allowed_types:
         allowed_types = [t.get('directory') for t in allowed_types]


### PR DESCRIPTION
It is not used anywhere in the code base. There is one reference in the task, but that can be safely replaced by tomlkit.