### PR TITLE
Fix parsing of branch names with slashes

### DIFF
--- a/news/112.bugfix.rst
+++ b/news/112.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with parsing branch names which contain slashes.

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -891,8 +891,8 @@ class VCSRequirement(FileRequirement):
             name = link.egg_fragment
         subdirectory = link.subdirectory_fragment
         ref = None
-        if "@" in link.show_url and "@" in uri:
-            uri, ref = uri.rsplit("@", 1)
+        if "@" in link.path and "@" in uri:
+            uri, _, ref = uri.rpartition("@")
         if relpath and "@" in relpath:
             relpath, ref = relpath.rsplit("@", 1)
         return cls(


### PR DESCRIPTION
- Fixes #112 
- ref: pypa/pipenv#3214

Signed-off-by: Dan Ryan <dan@danryan.co>