### PR TITLE
Don't write duplicate egg-info dir

### DIFF
--- a/news/115.bugfix.rst
+++ b/news/115.bugfix.rst
@@ -1,0 +1,1 @@
+Don't write redundant ``egg-info`` under project root when ``src`` is used as package base.

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -103,7 +103,7 @@ def iter_egginfos(path, pkg_name=None):
             if not entry.name.endswith("egg-info"):
                 for dir_entry in iter_egginfos(entry.path, pkg_name=pkg_name):
                     yield dir_entry
-            elif pkg_name is None or entry.name.startswith(pkg_name):
+            elif pkg_name is None or entry.name.startswith(pkg_name.replace("-", "_")):
                 yield entry
 
 
@@ -224,7 +224,7 @@ class SetupInfo(object):
             target_cwd = self.setup_py.parent.as_posix()
             with cd(target_cwd), _suppress_distutils_logs():
                 script_name = self.setup_py.as_posix()
-                args = ["egg_info", "--egg-base", self.base_dir]
+                args = ["egg_info"]
                 g = {"__file__": script_name, "__name__": "__main__"}
                 local_dict = {}
                 if sys.version_info < (3, 5):

--- a/tests/unit/test_setup_info.py
+++ b/tests/unit/test_setup_info.py
@@ -2,6 +2,7 @@
 
 import pytest
 import sys
+import os
 
 from requirementslib.models.requirements import Requirement
 
@@ -32,3 +33,12 @@ def test_remote_req(url_line, name, requires):
     if "typing" in requires and not sys.version_info < (3, 5):
         requires.remove("typing")
     assert sorted(list(setup_dict.get("requires").keys())) == sorted(requires)
+
+
+def test_no_duplicate_egg_info():
+    """When the package has 'src' directory, do not write egg-info in base dir."""
+    base_dir = os.path.abspath(os.getcwd())
+    r = Requirement.from_line("-e {}".format(base_dir))
+    egg_info_name = "{}.egg-info".format(r.name.replace("-", "_"))
+    assert os.path.isdir(os.path.join(base_dir, "src", egg_info_name))
+    assert not os.path.isdir(os.path.join(base_dir, egg_info_name))


### PR DESCRIPTION
Signed-off-by: Frost Ming <mianghong@gmail.com>

When the package is using `src` as package base path, requirementslib shouldn't write another egg info directory under root path.

Fix https://github.com/pypa/pipenv/issues/3238