### PR TITLE
Respect `src_dir` argument when cloning

### DIFF
--- a/news/133.bugfix.rst
+++ b/news/133.bugfix.rst
@@ -1,0 +1,1 @@
+``VCSRequirement.get_checkout_dir`` will now properly respect the ``src_dir`` argument.


### PR DESCRIPTION
- Allow `VCSRepository` objects to be cloned to the supplied `src_dir`
- Respect `src_dir` for non-local vcs repositories when supplied as an
  argument to `VCSRequirement.get_checkout_dir()`
- Fixes #133

Signed-off-by: Dan Ryan <dan@danryan.co>