### PR TITLE
Merge egg fragment with name in pep508 reqs

### DIFF
--- a/news/146.bugfix.rst
+++ b/news/146.bugfix.rst
@@ -1,0 +1,1 @@
+Egg fragments on ``PEP-508`` style direct URL dependencies are now disregarded rather than merged with the leading name.

--- a/src/requirementslib/models/url.py
+++ b/src/requirementslib/models/url.py
@@ -203,6 +203,12 @@ class URI(object):
             fragment = ""
             if parsed_dict["fragment"] is not None:
                 fragment = "{0}".format(parsed_dict["fragment"])
+                if fragment.startswith("egg="):
+                    name, extras = pip_shims.shims._strip_extras(name_with_extras)
+                    fragment_name, fragment_extras = pip_shims.shims._strip_extras(fragment)
+                    if fragment_extras and not extras:
+                        name_with_extras = "{0}{1}".format(name, fragment_extras)
+                    fragment = ""
             elif "&subdirectory" in parsed_dict["path"]:
                 path, fragment = cls.parse_subdirectory(parsed_dict["path"])
                 parsed_dict["path"] = path


### PR DESCRIPTION
- For PEP508 direct url requirements, egg fragments and names should be
  merged rather than combined when reconstructing urls
- Fixes #146

Signed-off-by: Dan Ryan <dan@danryan.co>