### PR TITLE
Respect special setup.cfg directives

### DIFF
--- a/news/150.bugfix.rst
+++ b/news/150.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which prevented handling special setup.cfg directives during dependency parsing.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author = Dan Ryan
 author_email = dan@danryan.co
 long_description = file: README.rst
 long_description_content_type = text/x-rst
+version = attr: requirementslib.__version__
 license = MIT
 license_file = LICENSE
 keywords =


### PR DESCRIPTION
- Add support for `file: ` and `attr: ` directives
- Fixes #150

Signed-off-by: Dan Ryan <dan@danryan.co>