### PR TITLE
Fixed handling of "@"-sign in file URLs.

### DIFF
--- a/news/168.bugfix.rst
+++ b/news/168.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed handling of ``@``-signs in  ``file:`` URLs, unbreaking the use of local packages in e.g. `Jenkins <https://jenkins.io>`_ workspaces.

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -541,7 +541,7 @@ def split_ref_from_uri(uri):
     parsed = urllib_parse.urlparse(uri)
     path = parsed.path
     ref = None
-    if "@" in path:
+    if parsed.scheme != "file" and "@" in path:
         path, _, ref = path.rpartition("@")
     parsed = parsed._replace(path=path)
     return (urllib_parse.urlunparse(parsed), ref)


### PR DESCRIPTION
TL;DR: pipenv is broken if you try to install a package from a local file
and the path to it has an "@"-sign somewhere in it. (Jenkins workspaces!)

Long version: Consider the following scenario: Your `Pipfile` contains a
package description like

     coolpkg = {path = "./foo/bar/coolpkg.tar.gz"}

and the absolute path to the `Pipfile` is `/blah/blubb@2/baz/Pipfile`,
pipenv constructs the URI

     file:///blah/blubb@2/baz/foo/bar/coolpkg.tar.gz#egg=coolpkg

Things are OK so far, but then `Line.line_is_installable` uses
`split_ref_from_uri`, passing the resulting line to `is_installable_file`.
The problem is that `split_ref_from_uri` is too naive and thinks the part
after the "@" is a ref, passing only `file:///blah/blubb` to
`is_installable_file`, which of course fails.

This fix changes `split_ref_from_uri` so that it never considers an "@" in a
`file:` URL to be a ref, files don't have branches/tags/hashes, after all.
I am not sure if this is the nicest place to fix this, but *some* kind of
fix is urgently needed: [Jenkins](https://jenkins.io) uses "@2", "@3", ...
suffixes in its workspace names, which effectively makes pipenv unusable
when you have local packages and one of the most common CI tools. :-(