### PR TITLE
Add fallback when other binops are found.

### DIFF
--- a/news/179.bugfix.rst
+++ b/news/179.bugfix.rst
@@ -1,0 +1,1 @@
+Fix AST parsing when ``setup.py`` contains binary operators other than ``+`` and ``-``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,7 +143,7 @@ ignore =
     #E121,E123,E126,E226,E24,E704,
     # Our additions:
     # E123: closing bracket does not match indentation of opening bracket’s line
-    # E203: whitespace before ‘:’
+    # E203: whitespace before ':'
     # E129: visually indented line with same indent as next logical line
     # E222: multiple spaces after operator
     # E231: missing whitespace after ','

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -712,11 +712,13 @@ def ast_unparse(item, initial_mapping=False, analyzer=None, recurse=True):  # no
                     item.right = right_item
                     unparsed = item
                 else:
-                    unparsed = right_item + left_item
+                    unparsed = left_item + right_item
             else:
                 unparsed = item
         elif isinstance(item.op, ast.Sub):
             unparsed = unparse(item.left) - unparse(item.right)
+        else:
+            unparsed = item
     elif isinstance(item, ast.Name):
         if not initial_mapping:
             unparsed = item.id

--- a/tests/fixtures/setup_py/package_with_extras_as_variable/setup.py
+++ b/tests/fixtures/setup_py/package_with_extras_as_variable/setup.py
@@ -5,7 +5,10 @@ from setuptools import find_packages, setup
 thisdir = os.path.abspath(os.path.dirname(__file__))
 version = "1.0.0"
 
-testing_extras = ["coverage", "flaky"]
+testing_extras = ["coverage"] + ["flaky"]
+
+def print_with_bin_ops():
+    print("=" * 10)
 
 setup(
     name="test_package",


### PR DESCRIPTION
Closes #179 

* Add fallback branch when other binops are found.
* Tweak tests to cover binop parsing.
* Replace non-ascii character in `setup.cfg` to avoid encoding issue.