### PR TITLE
Use 'python_full_version' if micro version requested

### DIFF
--- a/news/223.bugfix.rst
+++ b/news/223.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue that did not take into account micro versions when generating markers from ``python_requires``.

--- a/src/requirementslib/models/markers.py
+++ b/src/requirementslib/models/markers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import itertools
 import operator
+import re
 
 import attr
 import distlib.markers
@@ -199,7 +200,9 @@ def _get_specs(specset):
 def _group_by_op(specs):
     # type: (Union[Set[Specifier], SpecifierSet]) -> Iterator
     specs = [_get_specs(x) for x in list(specs)]
-    flattened = [(op, version) for spec in specs for op, version in spec]
+    flattened = [
+        ((op, len(version) > 2), version) for spec in specs for op, version in spec
+    ]
     specs = sorted(flattened)
     grouping = itertools.groupby(specs, key=operator.itemgetter(0))
     return grouping
@@ -275,7 +278,8 @@ def cleanup_pyspecs(specs, joiner="or"):
         "==": lambda x: "in" if len(x) > 1 else "==",
     }
     translation_keys = list(translation_map.keys())
-    for op, versions in _group_by_op(tuple(specs)):
+    for op_and_version_type, versions in _group_by_op(tuple(specs)):
+        op = op_and_version_type[0]
         versions = [version[1] for version in versions]
         versions = sorted(dedup(versions))
         op_key = next(iter(k for k in translation_keys if op in k), None)
@@ -284,8 +288,8 @@ def cleanup_pyspecs(specs, joiner="or"):
             version_value = translation_map[op_key][joiner](versions)
         if op in op_translations:
             op = op_translations[op](versions)
-        results[op] = version_value
-    return sorted([(k, v) for k, v in results.items()], key=operator.itemgetter(1))
+        results[(op, op_and_version_type[1])] = version_value
+    return sorted([(k[0], v) for k, v in results.items()], key=operator.itemgetter(1))
 
 
 @lru_cache(maxsize=1024)
@@ -658,9 +662,16 @@ def parse_marker_dict(marker_dict):
         return specset, finalized_marker
 
 
+def _contains_micro_version(version_string):
+    return re.search("\d+\.\d+\.\d+", version_string) is not None
+
+
 def format_pyversion(parts):
     op, val = parts
-    return "python_version {0} '{1}'".format(op, val)
+    version_marker = (
+        "python_full_version" if _contains_micro_version(val) else "python_version"
+    )
+    return "{0} {1} '{2}'".format(version_marker, op, val)
 
 
 def normalize_marker_str(marker):

--- a/tests/unit/test_markers.py
+++ b/tests/unit/test_markers.py
@@ -202,6 +202,16 @@ def test_contains_extras_or_pyversions(marker, contains_extras, contains_pyversi
             'python_version >= "2.7" and python_version not in "3.0, 3.1, 3.2, 3.3" and python_version ~= "3.7"',
         ),
         ("<=3.5,>=2.7", 'python_version >= "2.7" and python_version < "3.6"'),
+        (">=3.6.1", 'python_full_version >= "3.6.1"'),
+        ("!=3.2.1,>=3.1", 'python_version >= "3.1" and python_full_version != "3.2.1"'),
+        (
+            "!=3.0.*,!=3.1.1,!=3.1.2",
+            'python_version != "3.0" and python_full_version not in "3.1.1, 3.1.2"',
+        ),
+        (
+            "!=3.0.*,!=3.1.1,>=3.1.4",
+            'python_version != "3.0" and python_full_version != "3.1.1" and python_full_version >= "3.1.4"',
+        ),
     ],
 )
 def test_marker_from_specifier(marker, expected):


### PR DESCRIPTION
-  If the version requested includes a micro version, then use
   `python_full_version`

Closes #223

Some notes to the PR:

- All versions with microversions included are grouped together with their
  operators.
- To improve execution speed and avoid the re call later, I would have
  preferred to refactor `cleanup_pyspecs` to return information about the
  microversion/version.  However, that is a public function, so that would be
  breaking API compatibility.

I'm happy to hear any comments/suggestions!