### PR TITLE
Fix how deprecated versions are handled

### DIFF
--- a/news/228.bugfix.rst
+++ b/news/228.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue where the list of not-supported python versions in a marker was being truncated.

--- a/src/requirementslib/models/markers.py
+++ b/src/requirementslib/models/markers.py
@@ -557,7 +557,7 @@ def _split_specifierset_str(specset_str, prefix="=="):
     else:
         values = [v.strip() for v in specset_str.split(",")]
     if prefix == "!=" and any(v in values for v in DEPRECATED_VERSIONS):
-        values = DEPRECATED_VERSIONS[:]
+        values += DEPRECATED_VERSIONS[:]
     for value in sorted(values):
         specifiers.add(Specifier("{0}{1}".format(prefix, value)))
     return specifiers

--- a/tests/unit/test_markers.py
+++ b/tests/unit/test_markers.py
@@ -138,6 +138,12 @@ def test_get_extras(marker, extras):
             ),
             SpecifierSet("!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"),
         ),
+        (
+            Marker(
+                "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'"
+            ),
+            SpecifierSet("!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,>=2.7"),
+        ),
     ],
 )
 def test_get_pyversions(marker, pyversions):


### PR DESCRIPTION
- If any deprecated version (3.0 - 3.3) is requested to not be supported, then
  *add* all of them to the not-supported list
- This is instead of *replacing* the not-supported list

Fixes #228