### PR TITLE
Add the missing version bound

### DIFF
--- a/news/234.bugfix.rst
+++ b/news/234.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that ``1.x`` specifiers can't be parsed correctly.

--- a/src/requirementslib/models/markers.py
+++ b/src/requirementslib/models/markers.py
@@ -25,7 +25,7 @@ if MYPY_RUNNING:
     STRING_TYPE = Union[str, bytes, Text]
 
 
-MAX_VERSIONS = {2: 7, 3: 11, 4: 0}
+MAX_VERSIONS = {1: 7, 2: 7, 3: 11, 4: 0}
 DEPRECATED_VERSIONS = ["3.0", "3.1", "3.2", "3.3"]
 
 

--- a/tests/unit/test_markers.py
+++ b/tests/unit/test_markers.py
@@ -30,6 +30,7 @@ def test_format_version(version_tuple, version_str):
         (Specifier("<=3.6"), Specifier("<3.7")),
         (">2.6", Specifier(">=2.7")),
         (Specifier(">2.6"), Specifier(">=2.7")),
+        (">1.1", Specifier(">=1.2"))
     ],
 )
 def test_format_pyspec(specifier, rounded_specifier):


### PR DESCRIPTION
This PR makes the parsing more robust by adding the missing version bound for `1.x`.

Fix #234 