### PR TITLE
Retrireve meteadata from setup(**meta) dictionaries

### DIFF
--- a/news/241.bugfix.rst
+++ b/news/241.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug in ``setup.py`` parsing in which ``setup.py`` files which passed a dictionary to the ``setup`` function returned metadata that could not be meaningfully processed.

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -926,7 +926,7 @@ class Analyzer(ast.NodeVisitor):
         return unparsed
 
     def unparse_list(self, item):
-        return type(item)([unparse(el) for el in item])
+        return type(item)([self.unparse(el) for el in item])
 
     def unparse_tuple(self, item):
         return self.unparse_list(item)
@@ -965,6 +965,17 @@ class Analyzer(ast.NodeVisitor):
                 should_retry=False, function_map=dict(retries)
             )
         return self.resolved_function_names
+
+    def parse_setup_function(self):
+        setup = {}  # type: Dict[Any, Any]
+        self.unmap_binops()
+        function_names = self.parse_functions()
+        if "setup" in function_names:
+            setup = self.unparse(function_names["setup"])
+        keys = list(setup.keys())
+        if len(keys) == 1 and keys[0] is None:
+            _, setup = setup.popitem()
+        return setup
 
 
 def ast_unparse(item, initial_mapping=False, analyzer=None, recurse=True):  # noqa:C901

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -696,6 +696,7 @@ class Analyzer(ast.NodeVisitor):
         self.assignments = {}
         self.binOps = []
         self.binOps_map = {}
+        self.recurse = True
         super(Analyzer, self).__init__()
 
     def generic_visit(self, node):
@@ -709,6 +710,15 @@ class Analyzer(ast.NodeVisitor):
         if isinstance(node, ast.Assign):
             self.assignments.update(ast_unparse(node, initial_mapping=True))
         super(Analyzer, self).generic_visit(node)
+
+    @contextlib.contextmanager
+    def no_recurse(self):
+        original_recurse_val = self.recurse
+        try:
+            self.recurse = False
+            yield
+        finally:
+            self.recurse = original_recurse_val
 
     def visit_BinOp(self, node):
         node = ast_unparse(node, initial_mapping=True)
@@ -727,6 +737,202 @@ class Analyzer(ast.NodeVisitor):
         return next(
             iter(k for k in self.assignments if getattr(k, "id", "") == match.id), None
         )
+
+    def generic_unparse(self, item):
+        if any(isinstance(item, k) for k in AST_BINOP_MAP.keys()):
+            return AST_BINOP_MAP[type(item)]
+        elif any(isinstance(item, k) for k in AST_COMPARATORS.keys()):
+            return AST_COMPARATORS[type(item)]
+        return item
+
+    def unparse(self, item):
+        unparser = getattr(
+            self, "unparse_{0}".format(item.__class__.__name__), self.generic_unparse
+        )
+        return unparser(item)
+
+    def unparse_Dict(self, item):
+        # unparsed = dict(zip(unparse(item.keys), unparse(item.values)))
+        return dict(
+            (self.unparse(k), self.unparse(v)) for k, v in zip(item.keys, item.values)
+        )
+
+    def unparse_List(self, item):
+        return [self.unparse(el) for el in item.elts]
+
+    def unparse_Tuple(self, item):
+        return tuple([self.unparse(el) for el in item.elts])
+
+    def unparse_Str(self, item):
+        return item.s
+
+    def unparse_Subscript(self, item):
+        unparsed = self.unparse(item.value)
+        if isinstance(item.slice, ast.Index):
+            try:
+                unparsed = unparsed[self.unparse(item.slice.value)]
+            except KeyError:
+                # not everything can be looked up before runtime
+                unparsed = item
+        return unparsed
+
+    def unparse_Num(self, item):
+        return item.n
+
+    def unparse_BinOp(self, item):
+        if item in self.binOps_map:
+            unparsed = self.binOps_map[item]
+        else:
+            right_item = self.unparse(item.right)
+            left_item = self.unparse(item.left)
+            op = getattr(item, "op", None)
+            op_func = self.unparse(op) if op is not None else op
+            try:
+                unparsed = op_func(left_item, right_item)
+            except Exception:
+                unparsed = (left_item, op_func, right_item)
+        return unparsed
+
+    def unparse_Name(self, item):
+        unparsed = item.id
+        if not self.recurse:
+            return unparsed
+        if item in self.assignments and self.recurse:
+            items = self.unparse(self.assignments[item])
+            unparsed = items.get(item.id, item.id)
+        else:
+            assignment = self.match_assignment_name(item)
+            if assignment is not None:
+                items = self.unparse(self.assignments[assignment])
+                unparsed = items.get(item.id, item.id)
+        return unparsed
+
+    def unparse_NameConstant(self, item):
+        return item.value
+
+    def unparse_Constant(self, item):
+        return item.value
+
+    def unparse_Ellipsis(self, item):
+        return item.value
+
+    def unparse_Attribute(self, item):
+        attr_name = getattr(item, "value", None)
+        attr_attr = getattr(item, "attr", None)
+        name = None
+        name = self.unparse(attr_name) if attr_name is not None else attr_attr
+        if attr_name and not self.recurse:
+            name = attr_name
+        elif name and attr_attr:
+            if isinstance(name, six.string_types):
+                unparsed = ".".join([item for item in (name, attr_attr) if item])
+            else:
+                unparsed = item
+        elif attr_attr and not name:
+            unparsed = attr_attr
+        else:
+            unparsed = name if not unparsed else unparsed
+        return unparsed
+
+    def unparse_Compare(self, item):
+        if isinstance(item.left, ast.Attribute) or isinstance(item.left, ast.Str):
+            import importlib
+
+            left = unparse(item.left)
+            if "." in left:
+                name, _, val = left.rpartition(".")
+                left = getattr(importlib.import_module(name), val, left)
+            comparators = []
+            for comparator in item.comparators:
+                right = self.unparse(comparator)
+                if isinstance(comparator, ast.Attribute) and "." in right:
+                    name, _, val = right.rpartition(".")
+                    right = getattr(importlib.import_module(name), val, right)
+                comparators.append(right)
+            unparsed = (left, self.unparse(item.ops), comparators)
+        else:
+            unparsed = item
+        return unparsed
+
+    def unparse_IfExp(self, item):
+        ops, truth_vals = [], []
+        if isinstance(item.test, ast.Compare):
+            left, ops, right = self.unparse(item.test)
+        else:
+            result = self.unparse(item.test)
+            if isinstance(result, dict):
+                k, v = result.popitem()
+                if not v:
+                    truth_vals = [False]
+        for i, op in enumerate(ops):
+            if i == 0:
+                truth_vals.append(op(left, right[i]))
+            else:
+                truth_vals.append(op(right[i - 1], right[i]))
+        if all(truth_vals):
+            unparsed = self.unparse(item.body)
+        else:
+            unparsed = self.unparse(item.orelse)
+        return unparsed
+
+    def unparse_Call(self, item):
+        unparsed = {}
+        if isinstance(item.func, (ast.Name, ast.Attribute)):
+            func_name = self.unparse(item.func)
+        else:
+            try:
+                func_name = self.unparse(item.func)
+            except Exception:
+                func_name = None
+        if not func_name:
+            return {}
+        if isinstance(func_name, dict):
+            unparsed.update(func_name)
+            func_name = next(iter(func_name.keys()))
+        else:
+            unparsed[func_name] = {}
+        for key in ("kwargs", "keywords"):
+            val = getattr(item, key, [])
+            if val is None:
+                continue
+            for keyword in self.unparse(val):
+                unparsed[func_name].update(self.unparse(keyword))
+        return unparsed
+
+    def unparse_keyword(self, item):
+        return {self.unparse(item.arg): self.unparse(item.value)}
+
+    def unparse_Assign(self, item):
+        # XXX: DO NOT UNPARSE THIS
+        # XXX: If we unparse this it becomes impossible to map it back
+        # XXX: To the original node in the AST so we can find the
+        # XXX: Original reference
+        with self.no_recurse():
+            target = self.unparse(next(iter(item.targets)))
+            val = self.unparse(item.value)
+        if isinstance(target, (tuple, set, list)):
+            unparsed = dict(zip(target, val))
+        else:
+            unparsed = {target: val}
+        return unparsed
+
+    def unparse_Mapping(self, item):
+        unparsed = {}
+        for k, v in item.items():
+            try:
+                unparsed[self.unparse(k)] = self.unparse(v)
+            except TypeError:
+                unparsed[k] = self.unparse(v)
+        return unparsed
+
+    def unparse_list(self, item):
+        return type(item)([unparse(el) for el in item])
+
+    def unparse_tuple(self, item):
+        return self.unparse_list(item)
+
+    def unparse_str(self, item):
+        return item
 
     def parse_function_names(self, should_retry=True, function_map=None):
         if function_map is None:
@@ -896,15 +1102,21 @@ def ast_unparse(item, initial_mapping=False, analyzer=None, recurse=True):  # no
                 func_name = unparse(item.func)
             except Exception:
                 func_name = None
+        if func_name and not isinstance(func_name, dict):
+            unparsed[func_name] = {}
         if isinstance(func_name, dict):
             unparsed.update(func_name)
             func_name = next(iter(func_name.keys()))
-            for keyword in getattr(item, "keywords", []):
-                unparsed[func_name].update(unparse(keyword))
-        elif func_name:
-            unparsed[func_name] = {}
-            for keyword in getattr(item, "keywords", []):
-                unparsed[func_name].update(unparse(keyword))
+        if func_name:
+            for key in ("kwargs", "keywords"):
+                val = getattr(item, key, [])
+                if val is None:
+                    continue
+                if isinstance(val, ast.Name):
+                    unparsed[func_name] = val
+                else:
+                    for keyword in unparse(val):
+                        unparsed[func_name].update(unparse(keyword))
     elif isinstance(item, ast.keyword):
         unparsed = {unparse(item.arg): unparse(item.value)}
     elif isinstance(item, ast.Assign):

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -979,6 +979,9 @@ def ast_parse_setup_py(path):
     function_names = ast_analyzer.parse_functions()
     if "setup" in function_names:
         setup = ast_unparse(function_names["setup"], analyzer=ast_analyzer)
+    keys = list(setup.keys())
+    if len(keys) == 1 and keys[0] is None:
+        _, setup = setup.popitem()
     return setup
 
 
@@ -1405,8 +1408,8 @@ build-backend = "{1}"
         # type: () -> Dict[S, Any]
         """Wipe existing distribution info metadata for rebuilding.
 
-            Erases metadata from **self.egg_base** and unsets **self.requirements**
-            and **self.extras**.
+        Erases metadata from **self.egg_base** and unsets
+        **self.requirements** and **self.extras**.
         """
         for metadata_dir in os.listdir(self.egg_base):
             shutil.rmtree(metadata_dir, ignore_errors=True)
@@ -1428,7 +1431,8 @@ build-backend = "{1}"
 
     def get_egg_metadata(self, metadata_dir=None, metadata_type=None):
         # type: (Optional[AnyStr], Optional[AnyStr]) -> Dict[Any, Any]
-        """Given a metadata directory, return the corresponding metadata dictionary.
+        """Given a metadata directory, return the corresponding metadata
+        dictionary.
 
         :param Optional[str] metadata_dir: Root metadata path, default: `os.getcwd()`
         :param Optional[str] metadata_type: Type of metadata to search for, default None

--- a/tests/fixtures/setup_py/package_with_setup_from_dict/setup.py
+++ b/tests/fixtures/setup_py/package_with_setup_from_dict/setup.py
@@ -1,0 +1,18 @@
+from setuptools import find_packages, setup
+
+SETUP = {
+    "name": "test package",
+    "version": "1.0.0",
+    "author": "Test Package",
+    "author_email": "test@author.package",
+    "url": "https://fake.package/team/url.git",
+    "packages": find_packages(),
+    "install_requires": [],
+    "extras_require": {"tests": ["pytest", "flake8"]},
+    "license": "MIT",
+    "description": "This is a fake package",
+}
+
+
+if __name__ == "__main__":
+    setup(**SETUP)

--- a/tests/unit/test_setup_info.py
+++ b/tests/unit/test_setup_info.py
@@ -1,4 +1,5 @@
 # -*- coding=utf-8 -*-
+import ast
 import contextlib
 import os
 import shutil
@@ -10,7 +11,11 @@ import six
 import vistir
 
 from requirementslib.models.requirements import Requirement
-from requirementslib.models.setup_info import ast_parse_setup_py, parse_setup_cfg
+from requirementslib.models.setup_info import (
+    ast_parse_file,
+    ast_parse_setup_py,
+    parse_setup_cfg,
+)
 
 
 @pytest.mark.parametrize(
@@ -162,9 +167,9 @@ def test_extras(pathlib_tmpdir, setup_py_dir, setup_py_name, extras, dependencie
 
 
 def test_ast_parser_finds_variables(setup_py_dir):
-    parsed = ast_parse_setup_py(
-        setup_py_dir.joinpath("package_with_extras_as_variable/setup.py").as_posix()
-    )
+    target = setup_py_dir.joinpath("package_with_extras_as_variable/setup.py").as_posix()
+    parsed = ast_parse_setup_py(target)
+    analyzer = ast_parse_file(target)
     expected = {
         "name": "test_package",
         "version": "1.0.0",
@@ -184,14 +189,15 @@ def test_ast_parser_finds_variables(setup_py_dir):
             assert str(parsed[k]) == str(v), parsed[k]
         else:
             assert parsed[k] == v, parsed[k]
+    assert analyzer.parse_setup_function() == parsed
 
 
 def test_ast_parser_finds_fully_qualified_setup(setup_py_dir):
-    parsed = ast_parse_setup_py(
-        setup_py_dir.joinpath(
-            "package_using_fully_qualified_setuptools/setup.py"
-        ).as_posix()
-    )
+    target = setup_py_dir.joinpath(
+        "package_using_fully_qualified_setuptools/setup.py"
+    ).as_posix()
+    parsed = ast_parse_setup_py(target)
+    analyzer = ast_parse_file(target)
     expected = {
         "name": "test_package",
         "version": "1.0.0",
@@ -211,14 +217,15 @@ def test_ast_parser_finds_fully_qualified_setup(setup_py_dir):
             assert str(parsed[k]) == str(v), parsed[k]
         else:
             assert parsed[k] == v, parsed[k]
+    assert analyzer.parse_setup_function() == parsed
 
 
 def test_ast_parser_handles_binops(setup_py_dir):
-    parsed = ast_parse_setup_py(
-        setup_py_dir.joinpath(
-            "package_with_conditional_install_requires/setup.py"
-        ).as_posix()
-    )
+    target = setup_py_dir.joinpath(
+        "package_with_conditional_install_requires/setup.py"
+    ).as_posix()
+    parsed = ast_parse_setup_py(target)
+    analyzer = ast_parse_file(target)
     expected = [
         "azure-common>=1.1.5",
         "cryptography",
@@ -228,12 +235,13 @@ def test_ast_parser_handles_binops(setup_py_dir):
     if six.PY2:
         expected.append("futures")
     assert list(sorted(parsed["install_requires"])) == list(sorted(expected))
+    assert analyzer.parse_setup_function() == parsed
 
 
 def test_ast_parser_handles_binops(setup_py_dir):
-    parsed = ast_parse_setup_py(
-        setup_py_dir.joinpath("package_with_setup_from_dict/setup.py").as_posix()
-    )
+    target = setup_py_dir.joinpath("package_with_setup_from_dict/setup.py").as_posix()
+    parsed = ast_parse_setup_py(target)
+    analyzer = ast_parse_file(target)
     assert parsed["name"] == "test package"
     assert parsed["version"] == "1.0.0"
     expected = [
@@ -241,6 +249,7 @@ def test_ast_parser_handles_binops(setup_py_dir):
         "flake8",
     ]
     assert list(sorted(parsed["extras_require"]["tests"])) == list(sorted(expected))
+    assert analyzer.parse_setup_function() == parsed
 
 
 def test_setup_cfg_parser(setup_cfg_dir):
@@ -284,5 +293,11 @@ def test_ast_parser_handles_dependency_on_env_vars(
 def test_ast_parser_handles_exceptions(artifact_dir):
     path = artifact_dir.joinpath("git/pyinstaller/setup.py")
     result = ast_parse_setup_py(path.as_posix())
+    analyzer = ast_parse_file(path.as_posix())
     assert result is not None
     assert "altgraph" in result["install_requires"]
+    for k, v in analyzer.parse_setup_function().items():
+        assert k in result
+        assert result[k] == v or (
+            isinstance(v, dict) and isinstance(list(v.keys())[0], ast.Attribute)
+        )

--- a/tests/unit/test_setup_info.py
+++ b/tests/unit/test_setup_info.py
@@ -52,7 +52,8 @@ def test_remote_req(url_line, name, requires):
 
 
 def test_no_duplicate_egg_info():
-    """When the package has 'src' directory, do not write egg-info in base dir."""
+    """When the package has 'src' directory, do not write egg-info in base
+    dir."""
     base_dir = vistir.compat.Path(os.path.abspath(os.getcwd())).as_posix()
     r = Requirement.from_line("-e {}".format(base_dir))
     egg_info_name = "{}.egg-info".format(r.name.replace("-", "_"))
@@ -94,7 +95,8 @@ def test_no_duplicate_egg_info():
 
 @pytest.mark.needs_internet
 def test_without_extras(pathlib_tmpdir):
-    """Tests a setup.py or setup.cfg parse when extras returns None for some files"""
+    """Tests a setup.py or setup.cfg parse when extras returns None for some
+    files."""
     setup_dir = pathlib_tmpdir.joinpath("sanitized-package")
     setup_dir.mkdir()
     assert setup_dir.is_dir()
@@ -141,7 +143,7 @@ setup(
     ],
 )
 def test_extras(pathlib_tmpdir, setup_py_dir, setup_py_name, extras, dependencies):
-    """Test named extras as a dependency"""
+    """Test named extras as a dependency."""
     setup_dir = pathlib_tmpdir.joinpath("test_package")
     shutil.copytree(setup_py_dir.joinpath(setup_py_name).as_posix(), setup_dir.as_posix())
     assert setup_dir.is_dir()
@@ -226,6 +228,19 @@ def test_ast_parser_handles_binops(setup_py_dir):
     if six.PY2:
         expected.append("futures")
     assert list(sorted(parsed["install_requires"])) == list(sorted(expected))
+
+
+def test_ast_parser_handles_binops(setup_py_dir):
+    parsed = ast_parse_setup_py(
+        setup_py_dir.joinpath("package_with_setup_from_dict/setup.py").as_posix()
+    )
+    assert parsed["name"] == "test package"
+    assert parsed["version"] == "1.0.0"
+    expected = [
+        "pytest",
+        "flake8",
+    ]
+    assert list(sorted(parsed["extras_require"]["tests"])) == list(sorted(expected))
 
 
 def test_setup_cfg_parser(setup_cfg_dir):


### PR DESCRIPTION
- Ensure metadata passed into `setup` functions is retrieved even if
  passed as a dictionary expansion by reference
- Fixes #241

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>