### PR TITLE
Don't accept non-string values for name parsing

### DIFF
--- a/news/249.bugfix.rst
+++ b/news/249.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that non-string value for name argument will be taken as requirement name.

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -1013,7 +1013,7 @@ class Line(object):
             parsed_setup_py = self.parsed_setup_py
             if parsed_setup_py:
                 name = parsed_setup_py.get("name", "")
-                if name:
+                if name and isinstance(name, six.string_types):
                     return name
         return None
 

--- a/tests/fixtures/setup_py/package_with_funtion_call_as_name/setup.py
+++ b/tests/fixtures/setup_py/package_with_funtion_call_as_name/setup.py
@@ -1,0 +1,23 @@
+from setuptools import find_packages, setup
+
+
+def find_name():
+    return "foo"
+
+
+SETUP = {
+    "name": find_name(),
+    "version": "1.0.0",
+    "author": "Test Package",
+    "author_email": "test@author.package",
+    "url": "https://fake.package/team/url.git",
+    "packages": find_packages(),
+    "install_requires": [],
+    "extras_require": {"tests": ["pytest", "flake8"]},
+    "license": "MIT",
+    "description": "This is a fake package",
+}
+
+
+if __name__ == "__main__":
+    setup(**SETUP)

--- a/tests/unit/test_setup_info.py
+++ b/tests/unit/test_setup_info.py
@@ -252,6 +252,14 @@ def test_ast_parser_handles_binops(setup_py_dir):
     assert analyzer.parse_setup_function() == parsed
 
 
+def test_parse_function_call_as_name(setup_py_dir, pathlib_tmpdir):
+    package_dir = pathlib_tmpdir.joinpath("test-package").as_posix()
+    setup_dir = setup_py_dir.joinpath("package_with_funtion_call_as_name").as_posix()
+    shutil.copytree(setup_dir, package_dir)
+    req = Requirement.from_line("-e {}".format(package_dir))
+    assert req.name == "foo"
+
+
 def test_ast_parser_handles_repeated_assignments(setup_py_dir):
     target = setup_py_dir.joinpath(
         "package_with_repeated_assignments/setup.py"


### PR DESCRIPTION
This will make `name` be retrieved from the execution result of `setup.py`