### PR TITLE
Fix an issue for projects with an at sign (`@`) in the path

### DIFF
--- a/news/309.bugfix.rst
+++ b/news/309.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue for projects with an at sign (``@``) in the path

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -567,7 +567,7 @@ def split_ref_from_uri(uri):
     path = parsed.path if parsed.path else ""
     scheme = parsed.scheme if parsed.scheme else ""
     ref = None
-    if scheme != "file" and (re.match("^.*@[^/@]*$", path) or path.count('@') >= 2):
+    if scheme != "file" and (re.match("^.*@[^/@]*$", path) or path.count("@") >= 2):
         path, _, ref = path.rpartition("@")
     parsed = parsed._replace(path=path)
     return (parsed.url, ref)

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -565,7 +565,7 @@ def split_ref_from_uri(uri):
         raise TypeError("Expected a string, received {0!r}".format(uri))
     parsed = _get_parsed_url(uri)
     path = parsed.path if parsed.path else ""
-    scheme = parsed.scheme if parsed.scheme else ""
+    scheme = parsed.scheme if parsed.scheme else "file"
     ref = None
     if scheme != "file" and "@" in path:
         path, _, ref = path.rpartition("@")

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -565,9 +565,9 @@ def split_ref_from_uri(uri):
         raise TypeError("Expected a string, received {0!r}".format(uri))
     parsed = _get_parsed_url(uri)
     path = parsed.path if parsed.path else ""
-    scheme = parsed.scheme if parsed.scheme else "file"
+    scheme = parsed.scheme if parsed.scheme else ""
     ref = None
-    if scheme != "file" and "@" in path:
+    if scheme != "file" and re.match("^.*@[^/@]*$", path):
         path, _, ref = path.rpartition("@")
     parsed = parsed._replace(path=path)
     return (parsed.url, ref)

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -567,7 +567,7 @@ def split_ref_from_uri(uri):
     path = parsed.path if parsed.path else ""
     scheme = parsed.scheme if parsed.scheme else ""
     ref = None
-    if scheme != "file" and re.match("^.*@[^/@]*$", path):
+    if scheme != "file" and (re.match("^.*@[^/@]*$", path) or path.count('@') >= 2):
         path, _, ref = path.rpartition("@")
     parsed = parsed._replace(path=path)
     return (parsed.url, ref)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -104,22 +104,22 @@ def test_split_ref_from_uri():
     url = "https://github.com/sarugaku/plette.git"
     assert utils.split_ref_from_uri(url) == (
         "https://github.com/sarugaku/plette.git",
-        None
+        None,
     )
     url = "/Users/some.user@acme.com/dev/myproject"
     assert utils.split_ref_from_uri(url) == (
         "/Users/some.user@acme.com/dev/myproject",
-        None
+        None,
     )
     url = "https://user:password@github.com/sarugaku/plette.git"
     assert utils.split_ref_from_uri(url) == (
         "https://user:password@github.com/sarugaku/plette.git",
-        None
+        None,
     )
     url = "git+https://github.com/pypa/pipenv.git@master#egg=pipenv"
     assert utils.split_ref_from_uri(url) == (
         "git+https://github.com/pypa/pipenv.git#egg=pipenv",
-        "master"
+        "master",
     )
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -109,15 +109,21 @@ def test_split_ref_from_uri():
         "/Users/some.user@acme.com/dev/myproject",
         None,
     )
-    assert utils.split_ref_from_uri("https://user:password@github.com/sarugaku/plette.git") == (
+    assert utils.split_ref_from_uri(
+        "https://user:password@github.com/sarugaku/plette.git"
+    ) == (
         "https://user:password@github.com/sarugaku/plette.git",
         None,
     )
-    assert utils.split_ref_from_uri("git+https://github.com/pypa/pipenv.git@master#egg=pipenv") == (
+    assert utils.split_ref_from_uri(
+        "git+https://github.com/pypa/pipenv.git@master#egg=pipenv"
+    ) == (
         "git+https://github.com/pypa/pipenv.git#egg=pipenv",
         "master",
     )
-    assert utils.split_ref_from_uri("/Users/some.user@acme.com/dev/myproject@bugfix/309") == (
+    assert utils.split_ref_from_uri(
+        "/Users/some.user@acme.com/dev/myproject@bugfix/309"
+    ) == (
         "/Users/some.user@acme.com/dev/myproject",
         "bugfix/309",
     )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -101,25 +101,25 @@ def test_split_vcs_method_from_uri():
 
 
 def test_split_ref_from_uri():
-    url = "https://github.com/sarugaku/plette.git"
-    assert utils.split_ref_from_uri(url) == (
+    assert utils.split_ref_from_uri("https://github.com/sarugaku/plette.git") == (
         "https://github.com/sarugaku/plette.git",
         None,
     )
-    url = "/Users/some.user@acme.com/dev/myproject"
-    assert utils.split_ref_from_uri(url) == (
+    assert utils.split_ref_from_uri("/Users/some.user@acme.com/dev/myproject") == (
         "/Users/some.user@acme.com/dev/myproject",
         None,
     )
-    url = "https://user:password@github.com/sarugaku/plette.git"
-    assert utils.split_ref_from_uri(url) == (
+    assert utils.split_ref_from_uri("https://user:password@github.com/sarugaku/plette.git") == (
         "https://user:password@github.com/sarugaku/plette.git",
         None,
     )
-    url = "git+https://github.com/pypa/pipenv.git@master#egg=pipenv"
-    assert utils.split_ref_from_uri(url) == (
+    assert utils.split_ref_from_uri("git+https://github.com/pypa/pipenv.git@master#egg=pipenv") == (
         "git+https://github.com/pypa/pipenv.git#egg=pipenv",
         "master",
+    )
+    assert utils.split_ref_from_uri("/Users/some.user@acme.com/dev/myproject@bugfix/309") == (
+        "/Users/some.user@acme.com/dev/myproject",
+        "bugfix/309",
     )
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -100,6 +100,29 @@ def test_split_vcs_method_from_uri():
     )
 
 
+def test_split_ref_from_uri():
+    url = "https://github.com/sarugaku/plette.git"
+    assert utils.split_ref_from_uri(url) == (
+        "https://github.com/sarugaku/plette.git",
+        None
+    )
+    url = "/Users/some.user@acme.com/dev/myproject"
+    assert utils.split_ref_from_uri(url) == (
+        "/Users/some.user@acme.com/dev/myproject",
+        None
+    )
+    url = "https://user:password@github.com/sarugaku/plette.git"
+    assert utils.split_ref_from_uri(url) == (
+        "https://user:password@github.com/sarugaku/plette.git",
+        None
+    )
+    url = "git+https://github.com/pypa/pipenv.git@master#egg=pipenv"
+    assert utils.split_ref_from_uri(url) == (
+        "git+https://github.com/pypa/pipenv.git#egg=pipenv",
+        "master"
+    )
+
+
 # tests from pip-tools
 
 


### PR DESCRIPTION
It seems `requirementslib` is causing a crash in `pipenv` in some rare circumstances. If you define a package like this in a `Pipfile`:
```
myproject = {editable = true, path = "."}
```
and this project path contains an at sign (`@`), then requirementslib will parse the path wrong. The second clause in the added test case will fail without this fix.

Fixes #309