### PR TITLE
Fix build_pep517 when the link contains a url fragment that includes subdirectory.

### DIFF
--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -13,7 +13,7 @@ import sys
 from collections.abc import Iterable, Mapping
 from functools import lru_cache, partial
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import parse_qs, urlparse, urlunparse
 from weakref import finalize
 
 import attr
@@ -1229,9 +1229,15 @@ build-backend = "{1}"
                     ).strip()
                 )
             )
-            need_delete = True
+        parsed = urlparse(str(self.ireq.link))
+        subdir = parse_qs(parsed.fragment).get("subdirectory", [])
+        if subdir:
+            directory = f"{self.base_dir}/{subdir[0]}"
+        else:
+            directory = self.base_dir
+        need_delete = True
         result = build_pep517(
-            self.base_dir,
+            directory,
             self.extra_kwargs["build_dir"],
             config_settings=self.pep517_config,
             dist_type="wheel",


### PR DESCRIPTION
This was first discovered and patched within pipenv--a new version of setuptools 61.x changed behavior with regards to how it built the packages, so it is crucial that when the url fragment contains a subdirectory that it be passed in to `build_pep517`.