### PR TITLE
rewrite pip_shims imports so they can be correctly patched downstream by pipenv.

### DIFF
--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -23,6 +23,7 @@ from distlib.wheel import Wheel
 from packaging.markers import Marker
 from packaging.specifiers import SpecifierSet
 from packaging.version import parse
+from pip_shims import shims
 from pip_shims.utils import call_function_with_correct_args
 from platformdirs import user_cache_dir
 from vistir.contextmanagers import cd, temp_path
@@ -1503,18 +1504,16 @@ build-backend = "{1}"
     @lru_cache()
     def from_ireq(cls, ireq, subdir=None, finder=None, session=None):
         # type: (InstallRequirement, Optional[AnyStr], Optional[PackageFinder], Optional[requests.Session]) -> Optional[SetupInfo]
-        import pip_shims.shims
-
         if not ireq.link:
             return None
         if ireq.link.is_wheel:
             return None
         stack = ExitStack()
         if not session:
-            cmd = pip_shims.shims.InstallCommand()
+            cmd = shims.InstallCommand()
             options, _ = cmd.parser.parse_args([])
             session = cmd._build_session(options)
-        stack.enter_context(pip_shims.shims.global_tempdir_manager())
+        stack.enter_context(shims.global_tempdir_manager())
         vcs, uri = split_vcs_method_from_uri(ireq.link.url_without_fragment)
         parsed = urlparse(uri)
         if "file" in parsed.scheme:
@@ -1529,7 +1528,7 @@ build-backend = "{1}"
             is_file = True
             if "file:/" in uri and "file:///" not in uri:
                 uri = uri.replace("file:/", "file:///")
-            path = pip_shims.shims.url_to_path(uri)
+            path = shims.url_to_path(uri)
         kwargs = _prepare_wheel_building_kwargs(ireq)
         is_artifact_or_vcs = getattr(
             ireq.link, "is_vcs", getattr(ireq.link, "is_artifact", False)
@@ -1581,7 +1580,7 @@ build-backend = "{1}"
                     hashes=ireq.hashes(True),
                 )
             except ImportError:
-                pip_shims.shims.shim_unpack(
+                shims.shim_unpack(
                     download_dir=download_dir,
                     ireq=ireq,
                     only_download=only_download,

--- a/src/requirementslib/models/url.py
+++ b/src/requirementslib/models/url.py
@@ -6,8 +6,8 @@ from urllib.parse import unquote as url_unquote
 from urllib.parse import unquote_plus
 
 import attr
-import pip_shims.shims
 from orderedmultidict import omdict
+from pip_shims import shims
 from urllib3.util import parse_url as urllib3_parse
 from urllib3.util.url import Url
 
@@ -18,7 +18,7 @@ from .utils import extras_to_string, parse_extras
 if MYPY_RUNNING:
     from typing import Dict, Optional, Text, Tuple, TypeVar, Union
 
-    from pip_shims.shims import Link
+    from shims import Link
 
     _T = TypeVar("_T")
     STRING_TYPE = Union[bytes, str, Text]
@@ -139,7 +139,7 @@ class URI(object):
             if key == "egg":
                 from .utils import parse_extras
 
-                name, stripped_extras = pip_shims.shims._strip_extras(val)
+                name, stripped_extras = shims._strip_extras(val)
                 if stripped_extras:
                     extras = tuple(parse_extras(stripped_extras))
             elif key == "subdirectory":
@@ -370,7 +370,7 @@ class URI(object):
     @property
     def as_link(self):
         # type: () -> Link
-        link = pip_shims.shims.Link(
+        link = shims.Link(
             self.to_string(escape_password=False, strip_ssh=False, direct=False)
         )
         return link
@@ -480,16 +480,14 @@ def update_url_name_and_fragment(name_with_extras, ref, parsed_dict):
     if name_with_extras:
         fragment = ""  # type: Optional[str]
         parsed_extras = ()
-        name, extras = pip_shims.shims._strip_extras(name_with_extras)
+        name, extras = shims._strip_extras(name_with_extras)
         if extras:
             parsed_extras = parsed_extras + tuple(parse_extras(extras))
         if parsed_dict["fragment"] is not None:
             fragment = "{0}".format(parsed_dict["fragment"])
             if fragment.startswith("egg="):
                 _, _, fragment_part = fragment.partition("=")
-                fragment_name, fragment_extras = pip_shims.shims._strip_extras(
-                    fragment_part
-                )
+                fragment_name, fragment_extras = shims._strip_extras(fragment_part)
                 name = name if name else fragment_name
                 if fragment_extras:
                     parsed_extras = parsed_extras + tuple(parse_extras(fragment_extras))

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -8,9 +8,9 @@ from collections.abc import ItemsView, Mapping, Sequence, Set
 from pathlib import Path
 from urllib.parse import urlparse, urlsplit, urlunparse
 
-import pip_shims.shims
 import tomlkit
 import vistir
+from pip_shims import shims
 from vistir.compat import fs_decode
 from vistir.path import ensure_mkdir_p, is_valid_url
 
@@ -73,7 +73,7 @@ VCS_SCHEMES = [
 
 def is_installable_dir(path):
     # type: (STRING_TYPE) -> bool
-    if pip_shims.shims.is_installable_dir(path):
+    if shims.is_installable_dir(path):
         return True
     pyproject_path = os.path.join(path, "pyproject.toml")
     if os.path.exists(pyproject_path):
@@ -199,14 +199,14 @@ def is_installable_file(path):
     if is_local and not os.path.exists(normalized_path):
         return False
 
-    is_archive = pip_shims.shims.is_archive_file(normalized_path)
+    is_archive = shims.is_archive_file(normalized_path)
     is_local_project = os.path.isdir(normalized_path) and is_installable_dir(
         normalized_path
     )
     if is_local and is_local_project or is_archive:
         return True
 
-    if not is_local and pip_shims.shims.is_archive_file(parsed.path):
+    if not is_local and shims.is_archive_file(parsed.path):
         return True
 
     return False

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -2,10 +2,10 @@
 import os
 from pathlib import Path
 
-import pip_shims.shims
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from pip_shims import shims
 from vistir.contextmanagers import temp_environ
 
 from requirementslib.exceptions import RequirementError
@@ -212,7 +212,7 @@ def test_convert_from_pip(monkeypatch, expected, requirement):
         m.setattr(Requirement, "run_requires", mock_run_requires)
         m.setattr(SetupInfo, "get_info", mock_run_requires)
         m.setattr(Line, "get_setup_info", mock_run_requires)
-        m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
+        m.setattr(shims, "unpack_url", mock_unpack)
         pkg_name = next(iter(expected.keys()))
         pkg_pipfile = expected[pkg_name]
         line = Line(requirement)
@@ -234,7 +234,7 @@ def test_convert_from_pip(monkeypatch, expected, requirement):
 )
 def test_convert_from_pipfile(monkeypatch, requirement, expected):
     with monkeypatch.context() as m:
-        m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
+        m.setattr(shims, "unpack_url", mock_unpack)
         m.setattr(SetupInfo, "get_info", mock_run_requires)
         m.setattr(Requirement, "run_requires", mock_run_requires)
         pkg_name = next(iter(requirement.keys()))
@@ -250,7 +250,7 @@ def test_convert_from_pipfile(monkeypatch, requirement, expected):
 def test_convert_from_pipfile_vcs(monkeypatch):
     """ssh VCS links should be converted correctly."""
     with monkeypatch.context() as m:
-        m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
+        m.setattr(shims, "unpack_url", mock_unpack)
         pkg_name = "shellingham"
         pkg_pipfile = {"editable": True, "git": "git@github.com:sarugaku/shellingham.git"}
         req = Requirement.from_pipfile(pkg_name, pkg_pipfile)
@@ -294,7 +294,7 @@ def test_convert_from_pip_git_uri_normalize(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(Requirement, "run_requires", mock_run_requires)
         m.setattr(SetupInfo, "get_info", mock_run_requires)
-        m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
+        m.setattr(shims, "unpack_url", mock_unpack)
         dep = "git+git@host:user/repo.git#egg=myname"
         dep = Requirement.from_line(dep).as_pipfile()
         assert dep == {"myname": {"git": "git@host:user/repo.git"}}
@@ -304,7 +304,7 @@ def test_convert_from_pip_git_uri_normalize(monkeypatch):
 @pytest.mark.requirements
 def test_get_requirements(monkeypatch_if_needed):
     # Test eggs in URLs
-    # m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
+    # m.setattr(shims, "unpack_url", mock_unpack)
     # m.setattr(SetupInfo, "get_info", mock_run_requires)
     url_with_egg = Requirement.from_line(
         "https://github.com/IndustriaTech/django-user-clipboard/archive/0.6.1.zip#egg=django-user-clipboard"
@@ -433,7 +433,7 @@ def test_stdout_is_suppressed(capsys, tmpdir):
 
 def test_local_editable_ref(monkeypatch):
     with monkeypatch.context() as m:
-        m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
+        m.setattr(shims, "unpack_url", mock_unpack)
         path = Path(ARTIFACTS_DIR) / "git/requests"
         req = Requirement.from_pipfile(
             "requests", {"editable": True, "git": path.as_uri(), "ref": "2.18.4"}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,8 +2,8 @@
 import os
 from pathlib import Path
 
-import pip_shims.shims
 import pytest
+from pip_shims import shims
 from vistir.contextmanagers import temp_environ
 
 from requirementslib import utils as base_utils
@@ -169,7 +169,7 @@ def test_format_requirement_editable(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(SetupInfo, "get_info", mock_run_requires)
         m.setattr(Requirement, "run_requires", mock_run_requires)
-        m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
+        m.setattr(shims, "unpack_url", mock_unpack)
         ireq = Requirement.from_line("-e git+git://fake.org/x/y.git#egg=y").as_ireq()
         assert utils.format_requirement(ireq) == "-e git+git://fake.org/x/y.git#egg=y"
 


### PR DESCRIPTION
Currently imports are problematic around pip_shims in pipenv and largely because of the `import pip_shims.shims` pattern here which I have eliminated.   