### PR TITLE
Remove usage of pip-shims

### DIFF
--- a/news/334.feature.rst
+++ b/news/334.feature.rst
@@ -1,0 +1,7 @@
+``requirementslib`` has converted off of pip-shims project which had grown into a complicated interface to using ``pip``.
+It was problematic because ``pip-shims`` could never foresee and accommodate future looking changes to internal interfaces of ``pip``.
+Also, ``pip-shims`` slowed down this library and required downstream tools such as ``pipenv`` to continue vendoring it despite having already dropped usages.
+Due to the impact of this change, it requires a major version increase of ``requirementslib`` to ``2.0.0``
+To utilize version ``2.0.0`` of ``requirementslib``, ensure you have ``pip>=22.2`` as this has not been fully tested to support earlier versions of ``pip``
+Breakage of the internal ``pip`` interface usage is possible with earlier versions.
+Additionally, the interface on ``NamedRequierment`` renamed class method ``get_dependencies`` to ``dependencies`` and ``get_abstract_dependencies`` to ``abstract_dependencies`` in order to match interface with ``Line`` class and avoid naming collision with the utility methods they call.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ known_third_party = [
   "packaging",
   "parver",
   "pep517",
-  "pip_shims",
   "platformdirs",
   "plette",
   "pyparsing",

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     orderedmultidict
     packaging>=19.0
     pep517>=0.5.0
-    pip-shims>=0.6.0
+    pip>=22.2
     platformdirs
     plette[validation]
     python-dateutil

--- a/src/requirementslib/models/cache.py
+++ b/src/requirementslib/models/cache.py
@@ -8,7 +8,8 @@ import sys
 
 import vistir
 from packaging.requirements import Requirement
-from pip_shims.shims import FAVORITE_HASH, SafeFileCache
+from pip._internal.network.cache import SafeFileCache
+from pip._internal.utils.hashes import FAVORITE_HASH
 from platformdirs import user_cache_dir
 
 from .utils import as_tuple, get_pinned_version, key_from_req, lookup_table

--- a/src/requirementslib/models/cache.py
+++ b/src/requirementslib/models/cache.py
@@ -10,6 +10,7 @@ import vistir
 from packaging.requirements import Requirement
 from pip._internal.network.cache import SafeFileCache
 from pip._internal.utils.hashes import FAVORITE_HASH
+from pip._internal.vcs.versioncontrol import VcsSupport
 from platformdirs import user_cache_dir
 
 from .utils import as_tuple, get_pinned_version, key_from_req, lookup_table
@@ -203,8 +204,6 @@ class HashCache(SafeFileCache):
         super(HashCache, self).__init__(*args, **kwargs)
 
     def get_hash(self, location):
-        from pip_shims import VcsSupport
-
         # if there is no location hash (i.e., md5 / sha256 / etc) we on't want to store it
         hash_value = None
         vcs = VcsSupport()

--- a/src/requirementslib/models/cache.py
+++ b/src/requirementslib/models/cache.py
@@ -1,6 +1,3 @@
-# -*- coding=utf-8 -*-
-from __future__ import absolute_import, print_function, unicode_literals
-
 import atexit
 import copy
 import hashlib

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -214,7 +214,7 @@ class AbstractDependency(object):
 
             req = Requirement.from_line(key)
             req = req.merge_markers(self.markers)
-            self.dep_dict[key] = req.get_abstract_dependencies()
+            self.dep_dict[key] = req.abstract_dependencies()
         return self.dep_dict[key]
 
     @classmethod

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -16,6 +16,7 @@ from packaging.version import parse
 from pip._internal.cache import WheelCache
 from pip._internal.models.format_control import FormatControl
 from pip._internal.operations.build.build_tracker import get_build_tracker
+from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip_shims import shims
@@ -327,9 +328,9 @@ def get_dependencies(ireq):
         name = getattr(ireq, "project_name", getattr(ireq, "project", ireq.name))
         version = getattr(ireq, "version", None)
         if not version:
-            ireq = InstallRequirement.from_line("{0}".format(name))
+            ireq = install_req_from_line("{0}".format(name))
         else:
-            ireq = InstallRequirement.from_line("{0}=={1}".format(name, version))
+            ireq = install_req_from_line("{0}=={1}".format(name, version))
     getters = [
         get_dependencies_from_cache,
         get_dependencies_from_wheel_cache,
@@ -405,7 +406,7 @@ def get_dependencies_from_json(ireq):
         if not requires_dist:  # The API can return None for this.
             return
         for requires in requires_dist:
-            i = InstallRequirement.from_line(requires)
+            i = install_req_from_line(requires)
             # See above, we don't handle requirements with extras.
             if not _marker_contains_extra(i):
                 yield format_requirement(i)
@@ -441,7 +442,7 @@ def get_dependencies_from_cache(ireq):
     try:
         broken = False
         for line in cached:
-            dep_ireq = InstallRequirement.from_line(line)
+            dep_ireq = install_req_from_line(line)
             name = canonicalize_name(dep_ireq.name)
             if _marker_contains_extra(dep_ireq):
                 broken = True  # The "extra =" marker breaks everything.

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -23,7 +23,7 @@ from vistir.contextmanagers import temp_environ
 from vistir.path import create_tracked_tempdir
 
 from ..environment import MYPY_RUNNING
-from ..utils import _ensure_dir, prepare_pip_source_args
+from ..utils import _ensure_dir, get_package_finder, prepare_pip_source_args
 from .cache import CACHE_DIR, DependencyCache
 from .setup_info import SetupInfo
 from .utils import (
@@ -31,7 +31,6 @@ from .utils import (
     fix_requires_python_marker,
     format_requirement,
     full_groupby,
-    get_package_finder,
     is_pinned_requirement,
     key_from_ireq,
     make_install_requirement,

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -15,7 +15,7 @@ from packaging.utils import canonicalize_name
 from packaging.version import parse
 from pip_shims import shims
 from vistir.compat import fs_str
-from vistir.contextmanagers import cd, temp_environ
+from vistir.contextmanagers import temp_environ
 from vistir.path import create_tracked_tempdir
 
 from ..environment import MYPY_RUNNING

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -358,7 +358,7 @@ def get_dependencies_from_wheel_cache(ireq):
     if ireq.editable or not is_pinned_requirement(ireq):
         return
     with _get_wheel_cache() as wheel_cache:
-        matches = wheel_cache.get(ireq.link, name_from_req(ireq.req))
+        matches = wheel_cache.get(ireq.link, name_from_req(ireq.req), ireq.markers)
         if matches:
             matches = set(matches)
             if not DEPENDENCY_CACHE.get(ireq):
@@ -574,7 +574,7 @@ def start_resolver(finder=None, session=None, wheel_cache=None):
         with global_tempdir_manager(), get_build_tracker() as build_tracker:
             if not wheel_cache:
                 wheel_cache = _get_wheel_cache()
-            _ensure_dir(fs_str(os.path.join(wheel_cache.cache_dir, "wheels")))
+            _ensure_dir(str(os.path.join(wheel_cache.cache_dir, "wheels")))
             preparer = pip_command.make_requirement_preparer(
                 temp_build_dir=_build_dir,
                 options=pip_options,

--- a/src/requirementslib/models/old_pip_utils.py
+++ b/src/requirementslib/models/old_pip_utils.py
@@ -16,148 +16,147 @@ from vistir.path import rmtree
 logger = logging.getLogger(__name__)
 
 
-try:  # Required for pip>=22.1
-    from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional
 
-    from pip._internal.models.link import Link
-    from pip._internal.network.download import Downloader
-    from pip._internal.operations.prepare import (
-        File,
-        get_file_url,
-        get_http_url,
-        unpack_vcs_link,
-    )
-    from pip._internal.utils.hashes import Hashes
-    from pip._internal.utils.unpacking import unpack_file
+from pip._internal.models.link import Link
+from pip._internal.network.download import Downloader
+from pip._internal.operations.prepare import (
+    File,
+    get_file_url,
+    get_http_url,
+    unpack_vcs_link,
+)
+from pip._internal.utils.hashes import Hashes
+from pip._internal.utils.unpacking import unpack_file
 
-    def is_socket(path):
-        # type: (str) -> bool
-        return stat.S_ISSOCK(os.lstat(path).st_mode)
 
-    def copy2_fixed(src, dest):
-        # type: (str, str) -> None
-        """Wrap shutil.copy2() but map errors copying socket files to
-        SpecialFileError as expected.
+def is_socket(path):
+    # type: (str) -> bool
+    return stat.S_ISSOCK(os.lstat(path).st_mode)
 
-        See also https://bugs.python.org/issue37700.
-        """
-        try:
-            shutil.copy2(src, dest)
-        except OSError:
-            for f in [src, dest]:
-                try:
-                    is_socket_file = is_socket(f)
-                except OSError:
-                    # An error has already occurred. Another error here is not
-                    # a problem and we can ignore it.
-                    pass
-                else:
-                    if is_socket_file:
-                        raise shutil.SpecialFileError(
-                            "`{f}` is a socket".format(**locals())
-                        )
 
-            raise
+def copy2_fixed(src, dest):
+    # type: (str, str) -> None
+    """Wrap shutil.copy2() but map errors copying socket files to
+    SpecialFileError as expected.
 
-    def _copy2_ignoring_special_files(src: str, dest: str) -> None:
-        """Copying special files is not supported, but as a convenience to
-        users we skip errors copying them.
+    See also https://bugs.python.org/issue37700.
+    """
+    try:
+        shutil.copy2(src, dest)
+    except OSError:
+        for f in [src, dest]:
+            try:
+                is_socket_file = is_socket(f)
+            except OSError:
+                # An error has already occurred. Another error here is not
+                # a problem and we can ignore it.
+                pass
+            else:
+                if is_socket_file:
+                    raise shutil.SpecialFileError("`{f}` is a socket".format(**locals()))
 
-        This supports tools that may create e.g. socket files in the
-        project source directory.
-        """
-        try:
-            copy2_fixed(src, dest)
-        except shutil.SpecialFileError as e:
-            # SpecialFileError may be raised due to either the source or
-            # destination. If the destination was the cause then we would actually
-            # care, but since the destination directory is deleted prior to
-            # copy we ignore all of them assuming it is caused by the source.
-            logger.warning(
-                "Ignoring special file error '%s' encountered copying %s to %s.",
-                str(e),
-                src,
-                dest,
-            )
+        raise
 
-    def _copy_source_tree(source: str, target: str) -> None:
-        target_abspath = os.path.abspath(target)
-        target_basename = os.path.basename(target_abspath)
-        target_dirname = os.path.dirname(target_abspath)
 
-        def ignore(d: str, names: List[str]) -> List[str]:
-            skipped: List[str] = []
-            if d == source:
-                # Pulling in those directories can potentially be very slow,
-                # exclude the following directories if they appear in the top
-                # level dir (and only it).
-                # See discussion at https://github.com/pypa/pip/pull/6770
-                skipped += [".tox", ".nox"]
-            if os.path.abspath(d) == target_dirname:
-                # Prevent an infinite recursion if the target is in source.
-                # This can happen when TMPDIR is set to ${PWD}/...
-                # and we copy PWD to TMPDIR.
-                skipped += [target_basename]
-            return skipped
+def _copy2_ignoring_special_files(src: str, dest: str) -> None:
+    """Copying special files is not supported, but as a convenience to users we
+    skip errors copying them.
 
-        shutil.copytree(
-            source,
-            target,
-            ignore=ignore,
-            symlinks=True,
-            copy_function=_copy2_ignoring_special_files,
+    This supports tools that may create e.g. socket files in the project
+    source directory.
+    """
+    try:
+        copy2_fixed(src, dest)
+    except shutil.SpecialFileError as e:
+        # SpecialFileError may be raised due to either the source or
+        # destination. If the destination was the cause then we would actually
+        # care, but since the destination directory is deleted prior to
+        # copy we ignore all of them assuming it is caused by the source.
+        logger.warning(
+            "Ignoring special file error '%s' encountered copying %s to %s.",
+            str(e),
+            src,
+            dest,
         )
 
-    def old_unpack_url(
-        link: Link,
-        location: str,
-        download: Downloader,
-        verbosity: int,
-        download_dir: Optional[str] = None,
-        hashes: Optional[Hashes] = None,
-    ) -> Optional[File]:
-        """Unpack link into location, downloading if required.
 
-        :param hashes: A Hashes object, one of whose embedded hashes must match,
-            or HashMismatch will be raised. If the Hashes is empty, no matches are
-            required, and unhashable types of requirements (like VCS ones, which
-            would ordinarily raise HashUnsupported) are allowed.
-        """
-        # non-editable vcs urls
-        if link.is_vcs:
-            unpack_vcs_link(link, location, verbosity=verbosity)
-            return None
+def _copy_source_tree(source: str, target: str) -> None:
+    target_abspath = os.path.abspath(target)
+    target_basename = os.path.basename(target_abspath)
+    target_dirname = os.path.dirname(target_abspath)
 
-        # Once out-of-tree-builds are no longer supported, could potentially
-        # replace the below condition with `assert not link.is_existing_dir`
-        # - unpack_url does not need to be called for in-tree-builds.
-        #
-        # As further cleanup, _copy_source_tree and accompanying tests can
-        # be removed.
-        #
-        # TODO when use-deprecated=out-of-tree-build is removed
-        if link.is_existing_dir():
-            if os.path.isdir(location):
-                rmtree(location)
-            _copy_source_tree(link.file_path, location)
-            return None
+    def ignore(d: str, names: List[str]) -> List[str]:
+        skipped: List[str] = []
+        if d == source:
+            # Pulling in those directories can potentially be very slow,
+            # exclude the following directories if they appear in the top
+            # level dir (and only it).
+            # See discussion at https://github.com/pypa/pip/pull/6770
+            skipped += [".tox", ".nox"]
+        if os.path.abspath(d) == target_dirname:
+            # Prevent an infinite recursion if the target is in source.
+            # This can happen when TMPDIR is set to ${PWD}/...
+            # and we copy PWD to TMPDIR.
+            skipped += [target_basename]
+        return skipped
 
-        # file urls
-        if link.is_file:
-            file = get_file_url(link, download_dir, hashes=hashes)
-        # http urls
-        else:
-            file = get_http_url(
-                link,
-                download,
-                download_dir,
-                hashes=hashes,
-            )
-        # unpack the archive to the build dir location. even when only downloading
-        # archives, they have to be unpacked to parse dependencies, except wheels
-        if not link.is_wheel:
-            unpack_file(file.path, location, file.content_type)
-        return file
+    shutil.copytree(
+        source,
+        target,
+        ignore=ignore,
+        symlinks=True,
+        copy_function=_copy2_ignoring_special_files,
+    )
 
-except ImportError:
-    raise
+
+def old_unpack_url(
+    link: Link,
+    location: str,
+    download: Downloader,
+    verbosity: int,
+    download_dir: Optional[str] = None,
+    hashes: Optional[Hashes] = None,
+) -> Optional[File]:
+    """Unpack link into location, downloading if required.
+
+    :param hashes: A Hashes object, one of whose embedded hashes must match,
+        or HashMismatch will be raised. If the Hashes is empty, no matches are
+        required, and unhashable types of requirements (like VCS ones, which
+        would ordinarily raise HashUnsupported) are allowed.
+    """
+    # non-editable vcs urls
+    if link.is_vcs:
+        unpack_vcs_link(link, location, verbosity=verbosity)
+        return None
+
+    # Once out-of-tree-builds are no longer supported, could potentially
+    # replace the below condition with `assert not link.is_existing_dir`
+    # - unpack_url does not need to be called for in-tree-builds.
+    #
+    # As further cleanup, _copy_source_tree and accompanying tests can
+    # be removed.
+    #
+    # TODO when use-deprecated=out-of-tree-build is removed
+    if link.is_existing_dir():
+        if os.path.isdir(location):
+            rmtree(location)
+        _copy_source_tree(link.file_path, location)
+        return None
+
+    # file urls
+    if link.is_file:
+        file = get_file_url(link, download_dir, hashes=hashes)
+    # http urls
+    else:
+        file = get_http_url(
+            link,
+            download,
+            download_dir,
+            hashes=hashes,
+        )
+    # unpack the archive to the build dir location. even when only downloading
+    # archives, they have to be unpacked to parse dependencies, except wheels
+    if not link.is_wheel:
+        unpack_file(file.path, location, file.content_type)
+    return file

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -558,26 +558,25 @@ class Line(object):
         :rtype: :class:`~Line`
         """
         extras = None
-        if not self.line:
-            line = "{0}".format(self.line)
-            if any([self.is_vcs, self.is_url, "@" in line]):
-                try:
-                    if self.parsed_url.name:
-                        self._name = self.parsed_url.name
-                    if (
-                        self.parsed_url.host
-                        and self.parsed_url.path
-                        and self.parsed_url.scheme
-                    ):
-                        self.line = self.parsed_url.to_string(
-                            escape_password=False,
-                            direct=False,
-                            strip_ssh=self.parsed_url.is_implicit_ssh,
-                        )
-                except ValueError:
-                    self.line, extras = _strip_extras(self.line)
-            else:
+        line = "{0}".format(self.line)
+        if any([self.is_vcs, self.is_url, "@" in line]):
+            try:
+                if self.parsed_url.name:
+                    self._name = self.parsed_url.name
+                if (
+                    self.parsed_url.host
+                    and self.parsed_url.path
+                    and self.parsed_url.scheme
+                ):
+                    self.line = self.parsed_url.to_string(
+                        escape_password=False,
+                        direct=False,
+                        strip_ssh=self.parsed_url.is_implicit_ssh,
+                    )
+            except ValueError:
                 self.line, extras = _strip_extras(self.line)
+        else:
+            self.line, extras = _strip_extras(self.line)
         extras_set = set()  # type: Set[STRING_TYPE]
         if extras is not None:
             extras_set = set(parse_extras(extras))
@@ -588,6 +587,7 @@ class Line(object):
                 extras_set |= name_extras
         if extras_set is not None:
             self.extras = tuple(sorted(extras_set))
+        return self
 
     def get_url(self):
         # type: () -> STRING_TYPE
@@ -850,12 +850,14 @@ class Line(object):
             self._vcsrepo = self._get_vcsrepo()
         return self._vcsrepo
 
-    @cached_property
+    @property
     def parsed_url(self):
         # type: () -> URI
-        return URI.parse(self.line)
+        if self._parsed_url is None:
+            self._parsed_url = URI.parse(self.line)
+        return self._parsed_url
 
-    @cached_property
+    @property
     def is_direct_url(self):
         # type: () -> bool
         try:
@@ -1175,6 +1177,7 @@ class Line(object):
             self._link = parsed_link
         else:
             self._link = link
+        return self
 
     def parse_markers(self):
         # type: () -> None
@@ -2520,10 +2523,7 @@ class Requirement(object):
             else:
                 line_parts.append(self.req.line_part)
         if not self.is_vcs and not self.vcs and self.extras_as_pip:
-            if self.is_file_or_url:
-                line_parts.append(f"#egg={self.extras_as_pip}")
-            else:
-                line_parts.append(self.extras_as_pip)
+            line_parts.append(self.extras_as_pip)
         if self._specifiers and not (self.is_file_or_url or self.is_vcs):
             line_parts.append(self._specifiers)
         if self.markers:
@@ -2545,7 +2545,16 @@ class Requirement(object):
     @property
     def line_instance(self):
         # type: () -> Optional[Line]
-        return self.get_line_instance()
+        if self._line_instance is None:
+            self.line_instance = self.get_line_instance()
+        return self._line_instance
+
+    @line_instance.setter
+    def line_instance(self, line_instance):
+        # type: (Line) -> None
+        if self.req:
+            self.req._parsed_line = line_instance
+        self._line_instance = line_instance
 
     @property
     def specifiers(self):

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2517,13 +2517,18 @@ class Requirement(object):
     def get_line_instance(self):
         # type: () -> Line
         line_parts = []
+        local_editable = False
         if self.req:
             if self.req.line_part.startswith("-e "):
+                local_editable = True
                 line_parts.extend(self.req.line_part.split(" ", 1))
             else:
                 line_parts.append(self.req.line_part)
         if not self.is_vcs and not self.vcs and self.extras_as_pip:
-            line_parts.append(self.extras_as_pip)
+            if self.is_file_or_url and not local_editable:
+                line_parts.append(f"#egg={self.extras_as_pip}")
+            else:
+                line_parts.append(self.extras_as_pip)
         if self._specifiers and not (self.is_file_or_url or self.is_vcs):
             line_parts.append(self._specifiers)
         if self.markers:

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -656,7 +656,7 @@ class Line(object):
 
         if self.link is None:
             return False
-        return not self.link.is_vcs
+        return getattr(self.link, "is_vcs", False)
 
     @property
     def is_vcs(self):
@@ -1845,7 +1845,7 @@ class FileRequirement(object):
         seed = None  # type: Optional[STRING_TYPE]
         if self.link is not None:
             link_url = self.link.url_without_fragment
-        is_vcs = getattr(self.link, "is_vcs", not self.link.is_artifact)
+        is_vcs = getattr(self.link, "is_vcs", False)
         if self._uri_scheme and self._uri_scheme == "path":
             # We may need any one of these for passing to pip
             seed = self.path or link_url or self.uri
@@ -1894,7 +1894,7 @@ class FileRequirement(object):
         key_match = next(iter(k for k in collision_order if k in pipfile_dict.keys()))
         is_vcs = None
         if self.link is not None:
-            is_vcs = getattr(self.link, "is_vcs", not self.link.is_artifact)
+            is_vcs = getattr(self.link, "is_vcs", False)
         if self._uri_scheme:
             dict_key = self._uri_scheme
             target_key = dict_key if dict_key in pipfile_dict else key_match

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -1671,7 +1671,8 @@ class FileRequirement(object):
         return link
 
     @req.default
-    def get_requirement(self) -> RequirementType:
+    def get_requirement(self):
+        # type () -> RequirementType
         if self.name is None:
             if self._parsed_line is not None and self._parsed_line.name is not None:
                 self.name = self._parsed_line.name

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2929,7 +2929,7 @@ class Requirement(object):
     def ireq(self):
         return self.as_ireq()
 
-    def dependencies(self):
+    def dependencies(self, sources=None):
         """Retrieve the dependencies of the current requirement.
 
         Retrieves dependencies of the current requirement.  This only works on pinned
@@ -2940,7 +2940,11 @@ class Requirement(object):
         :return: A set of requirement strings of the dependencies of this requirement.
         :rtype: set(str)
         """
-        return get_dependencies(self.as_ireq())
+        if not sources:
+            sources = [
+                {"name": "pypi", "url": "https://pypi.org/simple", "verify_ssl": True}
+            ]
+        return get_dependencies(self.as_ireq(), sources=sources)
 
     def abstract_dependencies(self, sources=None):
         """Retrieve the abstract dependencies of this requirement.

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2965,7 +2965,7 @@ class Requirement(object):
                 {"url": "https://pypi.org/simple", "name": "pypi", "verify_ssl": True}
             ]
         if is_pinned_requirement(self.ireq):
-            deps = self.get_dependencies()
+            deps = self.dependencies()
         else:
             ireq = sorted(self.find_all_matches(), key=lambda k: k.version)
             deps = get_dependencies(ireq.pop())

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -20,6 +20,7 @@ from packaging.specifiers import (
     SpecifierSet,
 )
 from packaging.utils import canonicalize_name
+from packaging.version import parse
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.constructors import (
@@ -2821,6 +2822,9 @@ class Requirement(object):
             return Specifier(self.specifiers)
         except InvalidSpecifier:
             return LegacySpecifier(self.specifiers)
+
+    def get_version(self):
+        return parse(self.get_specifier().version)
 
     def get_requirement(self):
         req_line = self.req.req.line

--- a/src/requirementslib/models/resolvers.py
+++ b/src/requirementslib/models/resolvers.py
@@ -1,8 +1,7 @@
-# -*- coding=utf-8 -*-
 from contextlib import contextmanager
 
 import attr
-from pip_shims.shims import Wheel
+from pip._internal.models.wheel import Wheel
 
 from .cache import HashCache
 from .utils import format_requirement, is_pinned_requirement, version_from_ireq

--- a/src/requirementslib/models/resolvers.py
+++ b/src/requirementslib/models/resolvers.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 
 import attr
 from pip._internal.models.wheel import Wheel
+from pip._internal.vcs.versioncontrol import VcsSupport
 
 from .cache import HashCache
 from .utils import format_requirement, is_pinned_requirement, version_from_ireq
@@ -197,8 +198,6 @@ class DependencyResolver(object):
 
         if ireq.editable:
             return set()
-
-        from pip_shims import VcsSupport
 
         vcs = VcsSupport()
         if (

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -1532,7 +1532,9 @@ build-backend = "{1}"
                 uri = uri.replace("file:/", "file:///")
             path = url_to_path(uri)
         kwargs = _prepare_wheel_building_kwargs(ireq)
-        is_artifact_or_vcs = getattr(ireq.link, "is_vcs", False)
+        is_artifact_or_vcs = getattr(
+            ireq.link, "is_vcs", getattr(ireq.link, "is_artifact", False)
+        )
         is_vcs = True if vcs else is_artifact_or_vcs
         download_dir = None
         if not (ireq.editable and is_file and is_vcs):

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -1532,9 +1532,7 @@ build-backend = "{1}"
                 uri = uri.replace("file:/", "file:///")
             path = url_to_path(uri)
         kwargs = _prepare_wheel_building_kwargs(ireq)
-        is_artifact_or_vcs = getattr(
-            ireq.link, "is_vcs", getattr(ireq.link, "is_artifact", False)
-        )
+        is_artifact_or_vcs = getattr(ireq.link, "is_vcs", False)
         is_vcs = True if vcs else is_artifact_or_vcs
         download_dir = None
         if not (ireq.editable and is_file and is_vcs):

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -1,6 +1,3 @@
-# -*- coding=utf-8 -*-
-from __future__ import absolute_import, print_function
-
 import ast
 import atexit
 import configparser
@@ -23,8 +20,10 @@ from distlib.wheel import Wheel
 from packaging.markers import Marker
 from packaging.specifiers import SpecifierSet
 from packaging.version import parse
-from pip_shims import shims
-from pip_shims.utils import call_function_with_correct_args
+from pip._internal.commands.install import InstallCommand
+from pip._internal.network.download import Downloader
+from pip._internal.utils.temp_dir import global_tempdir_manager
+from pip._internal.utils.urls import url_to_path
 from platformdirs import user_cache_dir
 from vistir.contextmanagers import cd, temp_path
 from vistir.misc import run
@@ -32,6 +31,7 @@ from vistir.path import create_tracked_tempdir, ensure_mkdir_p, mkdir_p, rmtree
 
 from ..environment import MYPY_RUNNING
 from ..exceptions import RequirementError
+from .old_pip_utils import old_unpack_url
 from .utils import (
     get_default_pyproject_backend,
     get_name_variants,
@@ -73,7 +73,8 @@ if MYPY_RUNNING:
 
     import requests
     from packaging.requirements import Requirement as PackagingRequirement
-    from pip_shims.shims import InstallRequirement, PackageFinder
+    from pip._internal.index.package_finder import PackageFinder
+    from pip._internal.req.req_install import InstallRequirement
     from pkg_resources import DistInfoDistribution, EggInfoDistribution, PathMetadata
     from pkg_resources import Requirement as PkgResourcesRequirement
 
@@ -1510,10 +1511,10 @@ build-backend = "{1}"
             return None
         stack = ExitStack()
         if not session:
-            cmd = shims.InstallCommand()
+            cmd = InstallCommand()
             options, _ = cmd.parser.parse_args([])
             session = cmd._build_session(options)
-        stack.enter_context(shims.global_tempdir_manager())
+        stack.enter_context(global_tempdir_manager())
         vcs, uri = split_vcs_method_from_uri(ireq.link.url_without_fragment)
         parsed = urlparse(uri)
         if "file" in parsed.scheme:
@@ -1528,19 +1529,17 @@ build-backend = "{1}"
             is_file = True
             if "file:/" in uri and "file:///" not in uri:
                 uri = uri.replace("file:/", "file:///")
-            path = shims.url_to_path(uri)
+            path = url_to_path(uri)
         kwargs = _prepare_wheel_building_kwargs(ireq)
         is_artifact_or_vcs = getattr(
             ireq.link, "is_vcs", getattr(ireq.link, "is_artifact", False)
         )
         is_vcs = True if vcs else is_artifact_or_vcs
-
+        download_dir = None
         if not (ireq.editable and is_file and is_vcs):
             if ireq.is_wheel:
-                only_download = True
                 download_dir = kwargs["wheel_download_dir"]
             else:
-                only_download = False
                 download_dir = kwargs["download_dir"]
         elif path is not None and os.path.isdir(path):
             raise RequirementError(
@@ -1561,32 +1560,19 @@ build-backend = "{1}"
                 "autodelete": False,
                 "parallel_builds": True,
             }
-            call_function_with_correct_args(build_location_func, **build_kwargs)
+            build_location_func(**build_kwargs)
             ireq.ensure_has_source_dir(kwargs["src_dir"])
-            try:  # Support for pip >= 21.1
-                from pip._internal.network.download import Downloader
-
-                from requirementslib.models.old_pip_utils import old_unpack_url
-
-                location = None
-                if getattr(ireq, "source_dir", None):
-                    location = ireq.source_dir
-                old_unpack_url(
-                    link=ireq.link,
-                    location=location,
-                    download=Downloader(session, "off"),
-                    verbosity=1,
-                    download_dir=download_dir,
-                    hashes=ireq.hashes(True),
-                )
-            except ImportError:
-                shims.shim_unpack(
-                    download_dir=download_dir,
-                    ireq=ireq,
-                    only_download=only_download,
-                    session=session,
-                    hashes=ireq.hashes(False),
-                )
+            location = None
+            if getattr(ireq, "source_dir", None):
+                location = ireq.source_dir
+            old_unpack_url(
+                link=ireq.link,
+                location=location,
+                download=Downloader(session, "off"),
+                verbosity=1,
+                download_dir=download_dir,
+                hashes=ireq.hashes(True),
+            )
         created = cls.create(
             ireq.source_dir, subdirectory=subdir, ireq=ireq, kwargs=kwargs, stack=stack
         )

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -31,7 +31,7 @@ from vistir.path import create_tracked_tempdir, ensure_mkdir_p, mkdir_p, rmtree
 
 from ..environment import MYPY_RUNNING
 from ..exceptions import RequirementError
-from ..utils import pip_command
+from ..utils import get_pip_command
 from .old_pip_utils import old_unpack_url
 from .utils import (
     get_default_pyproject_backend,
@@ -1512,7 +1512,7 @@ build-backend = "{1}"
             return None
         stack = ExitStack()
         if not session:
-            cmd = pip_command()
+            cmd = get_pip_command()
             options, _ = cmd.parser.parse_args([])
             session = cmd._build_session(options)
         stack.enter_context(global_tempdir_manager())

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -31,6 +31,7 @@ from vistir.path import create_tracked_tempdir, ensure_mkdir_p, mkdir_p, rmtree
 
 from ..environment import MYPY_RUNNING
 from ..exceptions import RequirementError
+from ..utils import pip_command
 from .old_pip_utils import old_unpack_url
 from .utils import (
     get_default_pyproject_backend,
@@ -1511,7 +1512,7 @@ build-backend = "{1}"
             return None
         stack = ExitStack()
         if not session:
-            cmd = InstallCommand()
+            cmd = pip_command()
             options, _ = cmd.parser.parse_args([])
             session = cmd._build_session(options)
         stack.enter_context(global_tempdir_manager())

--- a/src/requirementslib/models/url.py
+++ b/src/requirementslib/models/url.py
@@ -7,7 +7,8 @@ from urllib.parse import unquote_plus
 
 import attr
 from orderedmultidict import omdict
-from pip_shims import shims
+from pip._internal.models.link import Link
+from pip._internal.req.constructors import _strip_extras
 from urllib3.util import parse_url as urllib3_parse
 from urllib3.util.url import Url
 
@@ -17,8 +18,6 @@ from .utils import extras_to_string, parse_extras
 
 if MYPY_RUNNING:
     from typing import Dict, Optional, Text, Tuple, TypeVar, Union
-
-    from shims import Link
 
     _T = TypeVar("_T")
     STRING_TYPE = Union[bytes, str, Text]
@@ -139,7 +138,7 @@ class URI(object):
             if key == "egg":
                 from .utils import parse_extras
 
-                name, stripped_extras = shims._strip_extras(val)
+                name, stripped_extras = _strip_extras(val)
                 if stripped_extras:
                     extras = tuple(parse_extras(stripped_extras))
             elif key == "subdirectory":
@@ -370,9 +369,7 @@ class URI(object):
     @property
     def as_link(self):
         # type: () -> Link
-        link = shims.Link(
-            self.to_string(escape_password=False, strip_ssh=False, direct=False)
-        )
+        link = Link(self.to_string(escape_password=False, strip_ssh=False, direct=False))
         return link
 
     @property
@@ -480,14 +477,14 @@ def update_url_name_and_fragment(name_with_extras, ref, parsed_dict):
     if name_with_extras:
         fragment = ""  # type: Optional[str]
         parsed_extras = ()
-        name, extras = shims._strip_extras(name_with_extras)
+        name, extras = _strip_extras(name_with_extras)
         if extras:
             parsed_extras = parsed_extras + tuple(parse_extras(extras))
         if parsed_dict["fragment"] is not None:
             fragment = "{0}".format(parsed_dict["fragment"])
             if fragment.startswith("egg="):
                 _, _, fragment_part = fragment.partition("=")
-                fragment_name, fragment_extras = shims._strip_extras(fragment_part)
+                fragment_name, fragment_extras = _strip_extras(fragment_part)
                 name = name if name else fragment_name
                 if fragment_extras:
                     parsed_extras = parsed_extras + tuple(parse_extras(fragment_extras))

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function
-
 import io
 import os
 import re
@@ -16,6 +13,8 @@ from attr import validators
 from packaging.markers import InvalidMarker, Marker, Op, Value, Variable
 from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
 from packaging.version import parse as parse_version
+from pip._internal.models.link import Link
+from pip._internal.req.constructors import install_req_from_line
 from plette.models import Package, PackageCollection
 from tomlkit.container import Container
 from tomlkit.items import AoT, Array, Bool, InlineTable, Item, String, Table
@@ -50,7 +49,6 @@ if MYPY_RUNNING:
     from packaging.markers import Value as PkgResourcesValue
     from packaging.markers import Variable as PkgResourcesVariable
     from packaging.requirements import Requirement as PackagingRequirement
-    from pip_shims.shims import Link
     from pkg_resources import Requirement as PkgResourcesRequirement
     from urllib3.util.url import Url
 
@@ -115,7 +113,6 @@ def create_link(link):
 
     if not isinstance(link, str):
         raise TypeError("must provide a string to instantiate a new link")
-    from pip_shims.shims import Link  # noqa: F811
 
     return Link(link)
 
@@ -309,11 +306,11 @@ def convert_direct_url_to_url(direct_url):
     # type: (AnyStr) -> AnyStr
     """Converts direct URLs to standard, link-style URLs.
 
-    Given a direct url as defined by *PEP 508*, convert to a :class:`~pip_shims.shims.Link`
+    Given a direct url as defined by *PEP 508*, convert to a :class:`Link`
     compatible URL by moving the name and extras into an **egg_fragment**.
 
     :param str direct_url: A pep-508 compliant direct url.
-    :return: A reformatted URL for use with Link objects and :class:`~pip_shims.shims.InstallRequirement` objects.
+    :return: A reformatted URL for use with Link objects and :class:`InstallRequirement` objects.
     :rtype: AnyStr
     """
     direct_match = DIRECT_URL_RE.match(direct_url)  # type: Optional[Match]
@@ -350,10 +347,10 @@ def convert_url_to_direct_url(url, name=None):
     # type: (AnyStr, Optional[AnyStr]) -> AnyStr
     """Converts normal link-style URLs to direct urls.
 
-    Given a :class:`~pip_shims.shims.Link` compatible URL, convert to a direct url as
+    Given a :class:`Link` compatible URL, convert to a direct url as
     defined by *PEP 508* by extracting the name and extras from the **egg_fragment**.
 
-    :param AnyStr url: A :class:`~pip_shims.shims.InstallRequirement` compliant URL.
+    :param AnyStr url: A :class:`InstallRequirement` compliant URL.
     :param Optiona[AnyStr] name: A name to use in case the supplied URL doesn't provide one.
     :return: A pep-508 compliant direct url.
     :rtype: AnyStr
@@ -871,11 +868,6 @@ def make_install_requirement(
     :return: A generated InstallRequirement
     :rtype: :class:`~pip._internal.req.req_install.InstallRequirement`
     """
-
-    # If no extras are specified, the extras string is blank
-    from pip_shims.shims import install_req_from_line
-
-    extras_string = ""
     requirement_string = "{0}".format(name)
     if extras:
         # Sort extras for stability

--- a/src/requirementslib/models/vcs.py
+++ b/src/requirementslib/models/vcs.py
@@ -1,12 +1,10 @@
-# -*- coding=utf-8 -*-
-from __future__ import absolute_import, print_function
-
 import importlib
 import os
 import sys
 
 import attr
-import pip_shims
+from pip._internal.utils.temp_dir import global_tempdir_manager
+from pip._internal.vcs.versioncontrol import VcsSupport
 
 from ..environment import MYPY_RUNNING
 from .url import URI
@@ -41,7 +39,6 @@ class VCSRepository(object):
             default_run_args = self.monkeypatch_pip()
         else:
             default_run_args = self.DEFAULT_RUN_ARGS
-        from pip_shims.shims import VcsSupport
 
         VCS_SUPPORT = VcsSupport()
         backend = VCS_SUPPORT.get_backend(self.vcs_type)
@@ -58,29 +55,13 @@ class VCSRepository(object):
             url = url.split("+")[1]
         return url.startswith("file")
 
-    def obtain(self, verbosity=1):
-        # type: () -> None
-        lt_pip_19_2 = (
-            pip_shims.parsed_pip_version.parsed_version < pip_shims.parse_version("19.2")
-        )
-        gte_pip_22_0 = (
-            pip_shims.parsed_pip_version.parsed_version >= pip_shims.parse_version("22.0")
-        )
-        if lt_pip_19_2:
-            self.repo_backend = self.repo_backend(self.url)
+    def obtain(self, verbosity=1) -> None:
         if os.path.exists(
             self.checkout_directory
         ) and not self.repo_backend.is_repository_directory(self.checkout_directory):
             self.repo_backend.unpack(self.checkout_directory)
         elif not os.path.exists(self.checkout_directory):
-            if lt_pip_19_2:
-                self.repo_backend.obtain(self.checkout_directory)
-            elif gte_pip_22_0:
-                self.repo_backend.obtain(
-                    self.checkout_directory, self.parsed_url, verbosity
-                )
-            else:  # at least Pip 19.2 but not quite pip 22.x
-                self.repo_backend.obtain(self.checkout_directory, self.parsed_url)
+            self.repo_backend.obtain(self.checkout_directory, self.parsed_url, verbosity)
         else:
             if self.ref:
                 self.checkout_ref(self.ref)
@@ -102,39 +83,24 @@ class VCSRepository(object):
     def update(self, ref):
         # type: (str) -> None
         target_ref = self.repo_backend.make_rev_options(ref)
-        if pip_shims.parse_version(pip_shims.pip_version) > pip_shims.parse_version(
-            "18.0"
-        ):
-            self.repo_backend.update(self.checkout_directory, self.url, target_ref)
-        else:
-            self.repo_backend.update(self.checkout_directory, target_ref)
+        self.repo_backend.update(self.checkout_directory, self.url, target_ref)
         self.commit_sha = self.get_commit_hash()
 
     def get_commit_hash(self, ref=None):
         # type: (Optional[str]) -> str
-        with pip_shims.shims.global_tempdir_manager():
+        with global_tempdir_manager():
             return self.repo_backend.get_revision(self.checkout_directory)
 
     @classmethod
     def monkeypatch_pip(cls):
         # type: () -> Tuple[Any, ...]
-        from pip_shims.compat import get_allowed_args
-
-        target_module = pip_shims.shims.VcsSupport.__module__
+        target_module = VcsSupport.__module__
         pip_vcs = importlib.import_module(target_module)
-        args, kwargs = get_allowed_args(pip_vcs.VersionControl.run_command)
         run_command_defaults = pip_vcs.VersionControl.run_command.__defaults__
-        if "show_stdout" not in args and "show_stdout" not in kwargs:
-            new_defaults = run_command_defaults
-        else:
-            # set the default to not write stdout, the first option sets this value
-            new_defaults = [False] + list(run_command_defaults)[1:]
-            new_defaults = tuple(new_defaults)
-        try:
-            pip_vcs.VersionControl.run_command.__defaults__ = new_defaults
-        except AttributeError:
-            pip_vcs.VersionControl.run_command.__func__.__defaults__ = new_defaults
-
+        # set the default to not write stdout, the first option sets this value
+        new_defaults = [False] + list(run_command_defaults)[1:]
+        new_defaults = tuple(new_defaults)
+        pip_vcs.VersionControl.run_command.__defaults__ = new_defaults
         sys.modules[target_module] = pip_vcs
         cls.DEFAULT_RUN_ARGS = new_defaults
         return new_defaults

--- a/src/requirementslib/models/vcs.py
+++ b/src/requirementslib/models/vcs.py
@@ -96,11 +96,11 @@ class VCSRepository(object):
         # type: () -> Tuple[Any, ...]
         target_module = VcsSupport.__module__
         pip_vcs = importlib.import_module(target_module)
-        run_command_defaults = pip_vcs.VersionControl.run_command.__defaults__
+        run_command_defaults = pip_vcs.VersionControl.run_command.__func__.__defaults__
         # set the default to not write stdout, the first option sets this value
         new_defaults = [False] + list(run_command_defaults)[1:]
         new_defaults = tuple(new_defaults)
-        pip_vcs.VersionControl.run_command.__defaults__ = new_defaults
+        pip_vcs.VersionControl.run_command.__func__.__defaults__ = new_defaults
         sys.modules[target_module] = pip_vcs
         cls.DEFAULT_RUN_ARGS = new_defaults
         return new_defaults

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse, urlsplit, urlunparse
 
 import tomlkit
 import vistir
+from pip._internal.commands.install import InstallCommand
 from pip._internal.models.target_python import TargetPython
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import is_installable_dir
@@ -672,3 +673,13 @@ def merge_items(target_list, sourced=False):
     if not sourced:
         return ret
     return ret, source_map
+
+
+def get_pip_command() -> InstallCommand:
+    # Use pip's parser for pip.conf management and defaults.
+    # General options (find_links, index_url, extra_index_url, trusted_host,
+    # and pre) are deferred to pip.
+    pip_command = InstallCommand(
+        name="InstallCommand", summary="requirementslib pip Install command."
+    )
+    return pip_command

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse, urlsplit, urlunparse
 
 import tomlkit
 import vistir
+from pip._internal.models.target_python import TargetPython
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import is_installable_dir
 from vistir.path import ensure_mkdir_p, is_valid_url
@@ -264,6 +265,35 @@ def prepare_pip_source_args(sources, pip_args=None):
                         ["--trusted-host", urlparse(source["url"]).hostname]
                     )  # type: ignore
     return pip_args
+
+
+def get_package_finder(
+    install_cmd=None,
+    options=None,
+    session=None,
+    platform=None,
+    python_versions=None,
+    abi=None,
+    implementation=None,
+    ignore_requires_python=None,
+):
+    """Reduced Shim for compatibility to generate package finders."""
+    py_version_info = None
+    if python_versions:
+        py_version_info_python = max(python_versions)
+        py_version_info = tuple([int(part) for part in py_version_info_python])
+    target_python = TargetPython(
+        platforms=[platform] if platform else None,
+        py_version_info=py_version_info,
+        abis=[abi] if abi else None,
+        implementation=implementation,
+    )
+    return install_cmd._build_package_finder(
+        options=options,
+        session=session,
+        target_python=target_python,
+        ignore_requires_python=ignore_requires_python,
+    )
 
 
 @ensure_mkdir_p(mode=0o777)

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -150,8 +150,8 @@ def convert_entry_to_path(path):
     elif "path" in path:
         path = path["path"]
     if not os.name == "nt":
-        return os.fs_decode(path)
-    return Path(os.fs_decode(path)).as_posix()
+        return os.fsdecode(path)
+    return Path(os.fsdecode(path)).as_posix()
 
 
 def is_installable_file(path):
@@ -180,7 +180,7 @@ def is_installable_file(path):
         or (len(parsed.scheme) == 1 and os.name == "nt")
     )
     if parsed.scheme and parsed.scheme == "file":
-        path = os.fs_decode(vistir.path.url_to_path(path))
+        path = os.fsdecode(vistir.path.url_to_path(path))
     normalized_path = vistir.path.normalize_path(path)
     if is_local and not os.path.exists(normalized_path):
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,6 @@ import shutil
 import warnings
 
 import distlib.wheel
-import pip_shims
 import pytest
 import requests
 import vistir
@@ -114,7 +113,6 @@ def monkeypatch_if_needed(monkeypatch):
 
     with monkeypatch.context() as m:
         if SKIP_INTERNET:
-            m.setattr(pip_shims.shims, "unpack_url", mock_unpack)
             m.setattr(SetupInfo, "get_info", mock_run_requires)
         yield
 

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -53,7 +53,7 @@ def test_two_deps():
 @pytest.mark.needs_internet
 def test_get_dependencies():
     r = Requirement.from_line("requests==2.19.1")
-    deps = r.get_dependencies()
+    deps = get_dependencies(r.as_ireq())
     assert len(deps) > 0
     deps_from_ireq = get_dependencies(r.as_ireq())
     assert len(deps_from_ireq) > 0
@@ -62,7 +62,7 @@ def test_get_dependencies():
 
 def get_abstract_deps():
     r = Requirement.from_line("requests")
-    deps = [InstallRequirement.from_line(d) for d in r.get_dependencies()]
+    deps = [InstallRequirement.from_line(d) for d in get_dependencies(r.as_ireq())]
     abstract_deps = r.get_abstract_dependencies()
     req_abstract_dep = AbstractDependency.from_requirement(r)
     assert r.abstract_dep == req_abstract_dep

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,7 +1,9 @@
 import pytest
 from packaging.specifiers import Specifier, SpecifierSet
-from pip._internal.req.constructors import install_req_from_line
-from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.constructors import (
+    install_req_from_editable,
+    install_req_from_line,
+)
 
 import requirementslib
 from requirementslib.models.dependencies import (
@@ -88,7 +90,7 @@ def test_get_deps_from_index():
 
 @pytest.mark.needs_internet
 def test_get_editable_from_index():
-    r = InstallRequirement.from_editable(
+    r = install_req_from_editable(
         "git+https://github.com/requests/requests.git#egg=requests[security]"
     )
     deps = get_dependencies_from_index(r)

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -63,7 +63,7 @@ def test_get_dependencies():
 def get_abstract_deps():
     r = Requirement.from_line("requests")
     deps = [InstallRequirement.from_line(d) for d in get_dependencies(r.as_ireq())]
-    abstract_deps = r.get_abstract_dependencies()
+    abstract_deps = r.abstract_dependencies()
     req_abstract_dep = AbstractDependency.from_requirement(r)
     assert r.abstract_dep == req_abstract_dep
     assert len(abstract_deps) > 0

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,6 +1,7 @@
 import pytest
 from packaging.specifiers import Specifier, SpecifierSet
 from pip._internal.req.constructors import install_req_from_line
+from pip._internal.req.req_install import InstallRequirement
 
 import requirementslib
 from requirementslib.models.dependencies import (

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,7 +1,6 @@
-# -*- coding=utf-8 -*-
 import pytest
 from packaging.specifiers import Specifier, SpecifierSet
-from pip_shims import InstallRequirement
+from pip._internal.req.constructors import install_req_from_line
 
 import requirementslib
 from requirementslib.models.dependencies import (
@@ -62,7 +61,7 @@ def test_get_dependencies():
 
 def get_abstract_deps():
     r = Requirement.from_line("requests")
-    deps = [InstallRequirement.from_line(d) for d in get_dependencies(r.as_ireq())]
+    deps = [install_req_from_line(d) for d in get_dependencies(r.as_ireq())]
     abstract_deps = r.abstract_dependencies()
     req_abstract_dep = AbstractDependency.from_requirement(r)
     assert r.abstract_dep == req_abstract_dep

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 
 import pytest
-from pip_shims import shims
 from vistir.contextmanagers import temp_environ
 
 from requirementslib import utils as base_utils
@@ -15,18 +14,6 @@ from requirementslib.models.utils import expand_env_variables
 
 def mock_run_requires(cls):
     return {}
-
-
-def mock_unpack(
-    link,
-    source_dir,
-    download_dir,
-    only_download=False,
-    session=None,
-    hashes=None,
-    progress_bar="off",
-):
-    return
 
 
 def test_filter_none():
@@ -169,7 +156,6 @@ def test_format_requirement_editable(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(SetupInfo, "get_info", mock_run_requires)
         m.setattr(Requirement, "run_requires", mock_run_requires)
-        m.setattr(shims, "unpack_url", mock_unpack)
         ireq = Requirement.from_line("-e git+git://fake.org/x/y.git#egg=y").as_ireq()
         assert utils.format_requirement(ireq) == "-e git+git://fake.org/x/y.git#egg=y"
 


### PR DESCRIPTION
``requirementslib`` has converted off of pip-shims project which had grown into a complicated interface to using ``pip``.
It was problematic because ``pip-shims`` could never foresee and accommodate future looking changes to internal interfaces of ``pip``.
Also, ``pip-shims`` slowed down this library and required downstream tools such as ``pipenv`` to continue vendoring it despite having already dropped usages.
Due to the impact of this change, it requires a major version increase of ``requirementslib`` to ``2.0.0``
To utilize version ``2.0.0`` of ``requirementslib``, ensure you have ``pip>=22.2`` as this has not been fully tested to support earlier versions of ``pip``
Breakage of the internal ``pip`` interface usage is possible with earlier versions.
Additionally, the interface on ``NamedRequierment`` renamed class method ``get_dependencies`` to ``dependencies`` and ``get_abstract_dependencies`` to ``abstract_dependencies`` in order to match interface with ``Line`` class and avoid naming collision with the utility methods they call.