### PR TITLE
Remove dateutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ known_third_party = [
   "attr",
   "cached_property",
   "chardet",
-  "dateutil",
   "distlib",
   "environ",
   "hypothesis",

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ install_requires =
     pip>=22.2
     platformdirs
     plette[validation]
-    python-dateutil
     requests
     setuptools>=40.8
     tomlkit>=0.5.3

--- a/src/requirementslib/models/metadata.py
+++ b/src/requirementslib/models/metadata.py
@@ -12,7 +12,6 @@ from functools import reduce
 from typing import Sequence
 
 import attr
-import dateutil.parser
 import distlib.metadata
 import distlib.wheel
 import requests
@@ -501,12 +500,17 @@ class ReleaseUrl(object):
     #: The upload timestamp from the package
     upload_time = attr.ib(
         type=datetime.datetime,
-        converter=instance_check_converter(datetime.datetime, dateutil.parser.parse),  # type: ignore
+        converter=instance_check_converter(
+            datetime.datetime, datetime.datetime.fromisoformat
+        ),  # type: ignore
     )
     #: The ISO8601 formatted upload timestamp of the package
     upload_time_iso_8601 = attr.ib(
         type=datetime.datetime,
-        converter=instance_check_converter(datetime.datetime, dateutil.parser.parse),  # type: ignore
+        converter=instance_check_converter(
+            datetime.datetime,
+            lambda t_str: datetime.datetime.strptime(t_str, "%Y-%m-%dT%H:%M:%S.%fZ"),
+        ),  # type: ignore
     )
     #: The size in bytes of the package
     size = attr.ib(type=int)


### PR DESCRIPTION
We parse a well known format which does not justify including
a dependency on such a magical library.