### PR TITLE
Drop ordered mutlidict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ known_third_party = [
   "attr",
   "cached_property",
   "chardet",
-  "dateutil",
   "distlib",
   "environ",
   "hypothesis",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ known_third_party = [
   "environ",
   "hypothesis",
   "invoke",
-  "orderedmultidict",
   "packaging",
   "parver",
   "pep517",

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ install_requires =
     pip>=22.2
     platformdirs
     plette[validation]
-    python-dateutil
     requests
     setuptools>=40.8
     tomlkit>=0.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests
     setuptools>=40.8
     tomlkit>=0.5.3
-    vistir>=0.3.1,<0.6
+    vistir==0.6.1
     pyparsing<3.0.0
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
     attrs>=19.2
     cached_property
     distlib>=0.2.8
-    orderedmultidict
     packaging>=19.0
     pep517>=0.5.0
     pip>=22.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests
     setuptools>=40.8
     tomlkit>=0.5.3
-    vistir>=0.3.1
+    vistir>=0.3.1,<0.6
     pyparsing<3.0.0
 
 [options.extras_require]

--- a/src/requirementslib/models/metadata.py
+++ b/src/requirementslib/models/metadata.py
@@ -12,7 +12,6 @@ from functools import reduce
 from typing import Sequence
 
 import attr
-import dateutil.parser
 import distlib.metadata
 import distlib.wheel
 import requests
@@ -501,12 +500,17 @@ class ReleaseUrl(object):
     #: The upload timestamp from the package
     upload_time = attr.ib(
         type=datetime.datetime,
-        converter=instance_check_converter(datetime.datetime, dateutil.parser.parse),  # type: ignore
+        converter=instance_check_converter(
+            datetime.datetime, datetime.datetime.fromisoformat
+        ),  # type: ignore
     )
     #: The ISO8601 formatted upload timestamp of the package
     upload_time_iso_8601 = attr.ib(
         type=datetime.datetime,
-        converter=instance_check_converter(datetime.datetime, dateutil.parser.parse),  # type: ignore
+        converter=instance_check_converter(
+            datetime.datetime,
+            lambda t_str: datetime.datetime.strptime(t_str, "%Y-%m-%dT%H:%M:%S.%fZ"),
+        ),  # type: ignore
     )
     #: The size in bytes of the package
     size = attr.ib(type=int)

--- a/src/requirementslib/models/url.py
+++ b/src/requirementslib/models/url.py
@@ -6,7 +6,6 @@ from urllib.parse import unquote as url_unquote
 from urllib.parse import unquote_plus
 
 import attr
-from orderedmultidict import omdict
 from pip._internal.models.link import Link
 from pip._internal.req.constructors import _strip_extras
 from urllib3.util import parse_url as urllib3_parse

--- a/src/requirementslib/models/url.py
+++ b/src/requirementslib/models/url.py
@@ -87,8 +87,8 @@ class URI(object):
     username = attr.ib(default="", type=str)
     #: Password parsed from `user:password@hostname`
     password = attr.ib(default="", type=str, repr=False)
-    #: An orderedmultidict representing query fragments
-    query_dict = attr.ib(factory=omdict, type=omdict)
+    #: A dictionary representing query fragments
+    query_dict = attr.ib(factory=dict, type=dict)
     #: The name of the specified package in case it is a VCS URI with an egg fragment
     name = attr.ib(default="", type=str)
     #: Any extras requested from the requirement
@@ -105,7 +105,7 @@ class URI(object):
     def _parse_query(self):
         # type: () -> URI
         query = self.query if self.query is not None else ""
-        query_dict = omdict()
+        query_dict = dict()
         queries = query.split("&")
         query_items = []
         subdirectory = self.subdirectory if self.subdirectory else None
@@ -116,7 +116,7 @@ class URI(object):
                 subdirectory = val
             else:
                 query_items.append((key, val))
-        query_dict.load(query_items)
+        query_dict.update(query_items)
         return attr.evolve(
             self, query_dict=query_dict, subdirectory=subdirectory, query=query
         )


### PR DESCRIPTION
This is never really used. As far as I understand

Fragments are everything that follows the # sign:

https://github.com/IndustriaTech/django-user-clipboard/archive/0.6.1.zip#egg=django-user-clipboard

I could be very wrong here, but it seems to me that there is only one
egg allowed in install url.

Here is what I found about Fragments:

https://pip.pypa.io/en/stable/topics/vcs-support/#url-fragments

I don't think there many people who use this feature... Especially not
to install multiple eggs from one repository. This would then justify
odmdict, e.g one would install from :

pkg_dir
├── setup.py  # setup.py for package "pkg"
└── some_module.py
pkg_dir2
├── setup.py  # setup.py for package "pkg"
└── some_module2.py
other_dir
└── some_file
some_other_file

python -m pip install -e "vcs+protocol://repo_url/#egg=pkg&subdirectory=pkg_dir&#egg=pkg2&subdirectory=pkg_dir2"

Is this even allowed? I don't know.