### PR TITLE
Fix bug with local file installs that are not marked editable = "true"

### DIFF
--- a/news/342.bugfix.rst
+++ b/news/342.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug with local file installs that are not marked ``editable = "true"`` getting an unexpected ``#egg`` fragment.

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2527,8 +2527,8 @@ class Requirement(object):
         if not self.is_vcs and not self.vcs and self.extras_as_pip:
             if (
                 self.is_file_or_url
-                and not self.req.get_uri().startswith("file://")
                 and not local_editable
+                and not self.req.get_uri().startswith("file://")
             ):
                 line_parts.append(f"#egg={self.extras_as_pip}")
             else:

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2517,13 +2517,22 @@ class Requirement(object):
     def get_line_instance(self):
         # type: () -> Line
         line_parts = []
+        local_editable = False
         if self.req:
             if self.req.line_part.startswith("-e "):
+                local_editable = True
                 line_parts.extend(self.req.line_part.split(" ", 1))
             else:
                 line_parts.append(self.req.line_part)
         if not self.is_vcs and not self.vcs and self.extras_as_pip:
-            line_parts.append(self.extras_as_pip)
+            if (
+                self.is_file_or_url
+                and not self.req.get_uri().startswith("file://")
+                and not local_editable
+            ):
+                line_parts.append(f"#egg={self.extras_as_pip}")
+            else:
+                line_parts.append(self.extras_as_pip)
         if self._specifiers and not (self.is_file_or_url or self.is_vcs):
             line_parts.append(self._specifiers)
         if self.markers:

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2517,18 +2517,13 @@ class Requirement(object):
     def get_line_instance(self):
         # type: () -> Line
         line_parts = []
-        local_editable = False
         if self.req:
             if self.req.line_part.startswith("-e "):
-                local_editable = True
                 line_parts.extend(self.req.line_part.split(" ", 1))
             else:
                 line_parts.append(self.req.line_part)
         if not self.is_vcs and not self.vcs and self.extras_as_pip:
-            if self.is_file_or_url and not local_editable:
-                line_parts.append(f"#egg={self.extras_as_pip}")
-            else:
-                line_parts.append(self.extras_as_pip)
+            line_parts.append(self.extras_as_pip)
         if self._specifiers and not (self.is_file_or_url or self.is_vcs):
             line_parts.append(self._specifiers)
         if self.markers:


### PR DESCRIPTION
Originally made this change because after dropping pip-shims the url encoding changed for the egg fragments and was missing for the URLs.  However this pipenv issue cropped up this morning:  https://github.com/pypa/pipenv/issues/5307

It appears that if the user doesn't specify `editable = "true"` we were falling into thinking it was a URL with a fragment.