### PR TITLE
Rely on packaging and pkg_resources internal to pip.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
     attrs>=19.2
     cached_property
     distlib>=0.2.8
-    packaging>=19.0
     pep517>=0.5.0
     pip>=22.2
     platformdirs

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ install_requires =
     setuptools>=40.8
     tomlkit>=0.5.3
     vistir==0.6.1
-    pyparsing<3.0.0
 
 [options.extras_require]
 tests =

--- a/src/requirementslib/environment.py
+++ b/src/requirementslib/environment.py
@@ -1,6 +1,3 @@
-# -*- coding=utf-8 -*-
-from __future__ import absolute_import, print_function
-
 import os
 
 from platformdirs import user_cache_dir

--- a/src/requirementslib/models/cache.py
+++ b/src/requirementslib/models/cache.py
@@ -3,11 +3,9 @@ import copy
 import hashlib
 import json
 import os
-import pathlib
-import sys
 
 import vistir
-from packaging.requirements import Requirement
+from pip._vendor.packaging.requirements import Requirement
 from pip._internal.utils.hashes import FAVORITE_HASH
 from pip._internal.vcs.versioncontrol import VcsSupport
 from pip._vendor.cachecontrol.cache import DictCache

--- a/src/requirementslib/models/cache.py
+++ b/src/requirementslib/models/cache.py
@@ -5,10 +5,10 @@ import json
 import os
 
 import vistir
-from pip._vendor.packaging.requirements import Requirement
 from pip._internal.utils.hashes import FAVORITE_HASH
 from pip._internal.vcs.versioncontrol import VcsSupport
 from pip._vendor.cachecontrol.cache import DictCache
+from pip._vendor.packaging.requirements import Requirement
 from platformdirs import user_cache_dir
 
 from .utils import as_tuple, get_pinned_version, key_from_req, lookup_table

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -1,18 +1,15 @@
-# -*- coding=utf-8 -*-
-
 import atexit
 import contextlib
 import copy
 import functools
 import os
-from contextlib import ExitStack
 from json import JSONDecodeError
 
 import attr
 import requests
-from packaging.markers import Marker
-from packaging.utils import canonicalize_name
-from packaging.version import parse
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import parse
 from pip._internal.cache import WheelCache
 from pip._internal.models.format_control import FormatControl
 from pip._internal.operations.build.build_tracker import get_build_tracker
@@ -35,7 +32,6 @@ from .cache import CACHE_DIR, DependencyCache
 from .setup_info import SetupInfo
 from .utils import (
     clean_requires_python,
-    fix_requires_python_marker,
     format_requirement,
     full_groupby,
     is_pinned_requirement,
@@ -49,18 +45,16 @@ if MYPY_RUNNING:
     from typing import (
         Any,
         Dict,
-        Generator,
         List,
         Optional,
         Set,
         Text,
-        Tuple,
         TypeVar,
         Union,
     )
 
-    from packaging.requirements import Requirement as PackagingRequirement
-    from pip._internal.commands.base_command import Command
+    from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
+    from pip._internal.commands import Command
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.models.candidate import InstallationCandidate
 

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -7,9 +7,6 @@ from json import JSONDecodeError
 
 import attr
 import requests
-from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import parse
 from pip._internal.cache import WheelCache
 from pip._internal.models.format_control import FormatControl
 from pip._internal.operations.build.build_tracker import get_build_tracker
@@ -17,6 +14,9 @@ from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.utils.temp_dir import TempDirectory, global_tempdir_manager
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import parse
 from vistir.compat import fs_str
 from vistir.contextmanagers import temp_environ
 from vistir.path import create_tracked_tempdir
@@ -42,21 +42,12 @@ from .utils import (
 )
 
 if MYPY_RUNNING:
-    from typing import (
-        Any,
-        Dict,
-        List,
-        Optional,
-        Set,
-        Text,
-        TypeVar,
-        Union,
-    )
+    from typing import Any, Dict, List, Optional, Set, Text, TypeVar, Union
 
-    from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
     from pip._internal.commands import Command
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.models.candidate import InstallationCandidate
+    from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
 
     TRequirement = TypeVar("TRequirement")
     RequirementType = TypeVar(

--- a/src/requirementslib/models/lockfile.py
+++ b/src/requirementslib/models/lockfile.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function
-
 import copy
 import itertools
 import os

--- a/src/requirementslib/models/markers.py
+++ b/src/requirementslib/models/markers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import itertools
 import operator
 import re
@@ -6,10 +5,10 @@ from collections.abc import Mapping, Set
 from functools import lru_cache, reduce
 
 import attr
-import distlib.markers
-from packaging.markers import InvalidMarker, Marker
-from packaging.specifiers import LegacySpecifier, Specifier, SpecifierSet
-from packaging.version import parse
+from distlib import markers
+from pip._vendor.packaging.markers import InvalidMarker, Marker
+from pip._vendor.packaging.specifiers import LegacySpecifier, Specifier, SpecifierSet
+from pip._vendor.packaging.version import parse
 from vistir.misc import dedup
 
 from ..environment import MYPY_RUNNING
@@ -514,7 +513,7 @@ def get_contained_pyversions(marker):
         return set()
     # Use the distlib dictionary parser to create a dictionary 'trie' which is a bit
     # easier to reason about
-    marker_dict = distlib.markers.parse_marker(marker_str)[0]
+    marker_dict = markers.parse_marker(marker_str)[0]
     version_set = set()
     pyversions, _ = parse_marker_dict(marker_dict)
     if isinstance(pyversions, set):

--- a/src/requirementslib/models/metadata.py
+++ b/src/requirementslib/models/metadata.py
@@ -11,7 +11,7 @@ from functools import reduce
 from typing import Sequence
 
 import attr
-from distlib import metadata
+from distlib.metadata import Metadata
 from distlib import wheel
 import requests
 import vistir
@@ -135,7 +135,7 @@ def validate_digest(inst, attrib, value):
 
 
 def get_local_wheel_metadata(wheel_file):
-    # type: (str) -> Optional[metadata.Metadata]
+    # type: (str) -> Optional[Metadata]
     parsed_metadata = None
     with io.open(wheel_file, "rb") as fh:
         with zipfile.ZipFile(fh, mode="r", compression=zipfile.ZIP_DEFLATED) as zf:
@@ -147,7 +147,7 @@ def get_local_wheel_metadata(wheel_file):
             if metadata is None:
                 raise RuntimeError("No metadata found in wheel: {0}".format(wheel_file))
             with zf.open(metadata, "r") as metadata_fh:
-                parsed_metadata = metadata.Metadata(fileobj=metadata_fh)
+                parsed_metadata = Metadata(fileobj=metadata_fh)
     return parsed_metadata
 
 
@@ -163,7 +163,7 @@ def get_remote_sdist_metadata(line):
 
 
 def get_remote_wheel_metadata(whl_file):
-    # type: (str) -> Optional[metadata.Metadata]
+    # type: (str) -> Optional[Metadata]
     parsed_metadata = None
     data = io.BytesIO()
     with vistir.contextmanagers.open_file(whl_file) as fp:
@@ -178,7 +178,7 @@ def get_remote_wheel_metadata(whl_file):
         if metadata is None:
             raise RuntimeError("No metadata found in wheel: {0}".format(whl_file))
         with zf.open(metadata, "r") as metadata_fh:
-            parsed_metadata = metadata.Metadata(fileobj=metadata_fh)
+            parsed_metadata = Metadata(fileobj=metadata_fh)
     return parsed_metadata
 
 

--- a/src/requirementslib/models/metadata.py
+++ b/src/requirementslib/models/metadata.py
@@ -256,11 +256,11 @@ class Dependency(object):
                 markers = [marker_from_specifier(str(s)) for s in specifiers]
             py_version_part = reduce(merge_markers, markers)
         if self.markers:
-            line_str = "{0}; {1}".format(line_str, str(self.markers))
+            line_str = "{0} ; {1}".format(line_str, str(self.markers))
             if py_version_part:
                 line_str = "{0} and {1}".format(line_str, py_version_part)
         elif py_version_part and not self.markers:
-            line_str = "{0}; {1}".format(line_str, py_version_part)
+            line_str = "{0} ; {1}".format(line_str, py_version_part)
         return line_str
 
     def pin(self):
@@ -348,7 +348,7 @@ class Dependency(object):
                     marker_str = "{0!s}".format(marker)
         req_str = "{0}=={1}".format(info.name, info.version)
         if marker_str:
-            req_str = "{0}; {1}".format(req_str, marker_str)
+            req_str = "{0} ; {1}".format(req_str, marker_str)
         req = PackagingRequirement(req_str)
         requires_python_str = (
             info.requires_python if info.requires_python is not None else ""
@@ -568,7 +568,7 @@ class ReleaseUrl(object):
         markers = self.markers
         req_str = "{0} @ {1}#egg={0}".format(self.name, self.url)
         if markers:
-            req_str = "{0}; {1}".format(req_str, markers)
+            req_str = "{0} ; {1}".format(req_str, markers)
         return req_str
 
     def get_markers_from_wheel(self):

--- a/src/requirementslib/models/metadata.py
+++ b/src/requirementslib/models/metadata.py
@@ -1,4 +1,3 @@
-# -*- coding=utf-8 -*-
 import datetime
 import functools
 import io
@@ -12,15 +11,15 @@ from functools import reduce
 from typing import Sequence
 
 import attr
-import distlib.metadata
-import distlib.wheel
+from distlib import metadata
+from distlib import wheel
 import requests
 import vistir
-from packaging.markers import Marker
-from packaging.requirements import Requirement as PackagingRequirement
-from packaging.specifiers import Specifier, SpecifierSet
-from packaging.tags import Tag
-from packaging.version import _BaseVersion, parse
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
+from pip._vendor.packaging.specifiers import Specifier, SpecifierSet
+from pip._vendor.packaging.tags import Tag
+from pip._vendor.packaging.version import _BaseVersion, parse
 
 from ..environment import MYPY_RUNNING
 from .markers import (
@@ -47,7 +46,6 @@ if MYPY_RUNNING:
         Any,
         Callable,
         Dict,
-        Generator,
         Generic,
         Iterator,
         List,
@@ -137,7 +135,7 @@ def validate_digest(inst, attrib, value):
 
 
 def get_local_wheel_metadata(wheel_file):
-    # type: (str) -> Optional[distlib.metadata.Metadata]
+    # type: (str) -> Optional[metadata.Metadata]
     parsed_metadata = None
     with io.open(wheel_file, "rb") as fh:
         with zipfile.ZipFile(fh, mode="r", compression=zipfile.ZIP_DEFLATED) as zf:
@@ -149,7 +147,7 @@ def get_local_wheel_metadata(wheel_file):
             if metadata is None:
                 raise RuntimeError("No metadata found in wheel: {0}".format(wheel_file))
             with zf.open(metadata, "r") as metadata_fh:
-                parsed_metadata = distlib.metadata.Metadata(fileobj=metadata_fh)
+                parsed_metadata = metadata.Metadata(fileobj=metadata_fh)
     return parsed_metadata
 
 
@@ -165,7 +163,7 @@ def get_remote_sdist_metadata(line):
 
 
 def get_remote_wheel_metadata(whl_file):
-    # type: (str) -> Optional[distlib.metadata.Metadata]
+    # type: (str) -> Optional[metadata.Metadata]
     parsed_metadata = None
     data = io.BytesIO()
     with vistir.contextmanagers.open_file(whl_file) as fp:
@@ -180,7 +178,7 @@ def get_remote_wheel_metadata(whl_file):
         if metadata is None:
             raise RuntimeError("No metadata found in wheel: {0}".format(whl_file))
         with zf.open(metadata, "r") as metadata_fh:
-            parsed_metadata = distlib.metadata.Metadata(fileobj=metadata_fh)
+            parsed_metadata = metadata.Metadata(fileobj=metadata_fh)
     return parsed_metadata
 
 
@@ -644,7 +642,7 @@ class ReleaseUrl(object):
         release_url = cls(**filter_dict(creation_kwargs))  # type: ignore
         if release_url.is_wheel:
             supported_tags = [
-                parse_tag(Tag(*tag)) for tag in distlib.wheel.Wheel(release_url.url).tags
+                parse_tag(Tag(*tag)) for tag in wheel.Wheel(release_url.url).tags
             ]
             release_url = attr.evolve(release_url, tags=supported_tags)
         return release_url

--- a/src/requirementslib/models/metadata.py
+++ b/src/requirementslib/models/metadata.py
@@ -11,10 +11,10 @@ from functools import reduce
 from typing import Sequence
 
 import attr
-from distlib.metadata import Metadata
-from distlib import wheel
 import requests
 import vistir
+from distlib import wheel
+from distlib.metadata import Metadata
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
 from pip._vendor.packaging.specifiers import Specifier, SpecifierSet
@@ -856,8 +856,8 @@ class ReleaseCollection(object):
     def wheels(self):
         # type: () -> Iterator[ReleaseUrl]
         for release in self.sort_releases():
-            for wheel in release.wheels:
-                yield wheel
+            for w in release.wheels:
+                yield w
 
     def sdists(self):
         # type: () -> Iterator[ReleaseUrl]
@@ -1058,8 +1058,8 @@ class Package(object):
     @property
     def latest_wheels(self):
         # type: () -> Iterator[ReleaseUrl]
-        for wheel in self.urls.wheels:
-            yield wheel
+        for w in self.urls.wheels:
+            yield w
 
     @property
     def dependencies(self):

--- a/src/requirementslib/models/pipfile.py
+++ b/src/requirementslib/models/pipfile.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import, print_function, unicode_literals
-
 import copy
 import itertools
 import os

--- a/src/requirementslib/models/project.py
+++ b/src/requirementslib/models/project.py
@@ -1,7 +1,3 @@
-# -*- coding=utf-8 -*-
-
-from __future__ import absolute_import, print_function, unicode_literals
-
 import collections
 import io
 import os

--- a/src/requirementslib/models/project.py
+++ b/src/requirementslib/models/project.py
@@ -10,8 +10,8 @@ import attr
 import plette
 import plette.models
 import tomlkit
-from packaging.markers import Marker
-from packaging.utils import canonicalize_name
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.utils import canonicalize_name
 
 SectionDifference = collections.namedtuple("SectionDifference", ["inthis", "inthat"])
 FileDifference = collections.namedtuple("FileDifference", ["default", "develop"])

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -1286,7 +1286,6 @@ class Line(object):
         if self.markers:
             self.markers = self.markers.replace('"', "'")
         self.parse_extras()
-        self.line = self.line.strip('"').strip("'").strip()
         if self.line.startswith("git+file:/") and not self.line.startswith(
             "git+file:///"
         ):

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -11,16 +11,16 @@ from urllib.parse import unquote
 
 import attr
 from cached_property import cached_property
-from packaging.markers import Marker
-from packaging.requirements import Requirement as PackagingRequirement
-from packaging.specifiers import (
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
+from pip._vendor.packaging.specifiers import (
     InvalidSpecifier,
     LegacySpecifier,
     Specifier,
     SpecifierSet,
 )
-from packaging.utils import canonicalize_name
-from packaging.version import parse
+from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import parse
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.constructors import (
@@ -60,7 +60,6 @@ from .setup_info import (
     _prepare_wheel_building_kwargs,
     ast_parse_setup_py,
     get_metadata,
-    parse_setup_cfg,
 )
 from .url import URI
 from .utils import (

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -11,16 +11,6 @@ from urllib.parse import unquote
 
 import attr
 from cached_property import cached_property
-from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
-from pip._vendor.packaging.specifiers import (
-    InvalidSpecifier,
-    LegacySpecifier,
-    Specifier,
-    SpecifierSet,
-)
-from pip._vendor.packaging.utils import canonicalize_name
-from pip._vendor.packaging.version import parse
 from pip._internal.models.link import Link
 from pip._internal.models.wheel import Wheel
 from pip._internal.req.constructors import (
@@ -31,6 +21,16 @@ from pip._internal.req.constructors import (
 from pip._internal.req.req_install import InstallRequirement
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.urls import path_to_url, url_to_path
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
+from pip._vendor.packaging.specifiers import (
+    InvalidSpecifier,
+    LegacySpecifier,
+    Specifier,
+    SpecifierSet,
+)
+from pip._vendor.packaging.utils import canonicalize_name
+from pip._vendor.packaging.version import parse
 from vistir.contextmanagers import temp_path
 from vistir.misc import dedup
 from vistir.path import (

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -204,7 +204,7 @@ class Line(object):
     def __str__(self):
         # type: () -> str
         if self.markers:
-            return "{0}; {1}".format(self.get_line(), self.markers)
+            return "{0} ; {1}".format(self.get_line(), self.markers)
         return self.get_line()
 
     def get_line(
@@ -236,7 +236,7 @@ class Line(object):
         # we anticipate this will be used if passing directly to the command line
         # for pip.
         if with_markers and self.markers:
-            line = "{0}; {1}".format(line, self.markers)
+            line = "{0} ; {1}".format(line, self.markers)
             if with_prefix and self.editable and not as_list:
                 line = '"{0}"'.format(line)
         if as_list:
@@ -1182,7 +1182,7 @@ class Line(object):
         # type: () -> None
         if self.markers:
             marker_str = self.markers.replace('"', "'")
-            markers = PackagingRequirement("fakepkg; {0}".format(marker_str)).marker
+            markers = PackagingRequirement("fakepkg ; {0}".format(marker_str)).marker
             self.parsed_marker = markers
 
     @property
@@ -2535,7 +2535,7 @@ class Requirement(object):
         if self._specifiers and not (self.is_file_or_url or self.is_vcs):
             line_parts.append(self._specifiers)
         if self.markers:
-            line_parts.append("; {0}".format(self.markers.replace('"', "'")))
+            line_parts.append(" ; {0}".format(self.markers.replace('"', "'")))
         if self.hashes_as_pip and not (self.editable or self.vcs or self.is_vcs):
             line_parts.append(self.hashes_as_pip)
         if self.editable:
@@ -2694,7 +2694,9 @@ class Requirement(object):
             r = named_req_from_parsed_line(parsed_line)
         req_markers = None
         if parsed_line.markers:
-            req_markers = PackagingRequirement("fakepkg; {0}".format(parsed_line.markers))
+            req_markers = PackagingRequirement(
+                "fakepkg ; {0}".format(parsed_line.markers)
+            )
         if r is not None and r.req is not None:
             r.req.marker = getattr(req_markers, "marker", None) if req_markers else None
         args = {}  # type: Dict[STRING_TYPE, CREATION_ARG_TYPES]
@@ -2753,7 +2755,7 @@ class Requirement(object):
         req_markers = None
         if markers:
             markers = str(markers)
-            req_markers = PackagingRequirement("fakepkg; {0}".format(markers))
+            req_markers = PackagingRequirement("fakepkg ; {0}".format(markers))
             if r.req is not None:
                 r.req.marker = req_markers.marker
         extras = _pipfile.get("extras")
@@ -2820,7 +2822,7 @@ class Requirement(object):
         # type: () -> Marker
         markers = self.markers
         if markers:
-            fake_pkg = PackagingRequirement("fakepkg; {0}".format(markers))
+            fake_pkg = PackagingRequirement("fakepkg ; {0}".format(markers))
             markers = fake_pkg.marker
         return markers
 

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -1181,8 +1181,7 @@ class Line(object):
     def parse_markers(self):
         # type: () -> None
         if self.markers:
-            marker_str = self.markers.replace('"', "'")
-            markers = PackagingRequirement("fakepkg ; {0}".format(marker_str)).marker
+            pkg_name, markers = split_markers_from_line(self.line)
             self.parsed_marker = markers
 
     @property

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -21,11 +21,11 @@ from pip._internal.network.download import Downloader
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.urls import url_to_path
 from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.version import parse
 from pip._vendor.pkg_resources import (
     PathMetadata,
+    Requirement,
     distributions_from_metadata,
     find_distributions,
 )
@@ -65,6 +65,7 @@ if MYPY_RUNNING:
 
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.req.req_install import InstallRequirement
+    from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
     from pip._vendor.pkg_resources import DistInfoDistribution, EggInfoDistribution
     from pip._vendor.requests import Session
 
@@ -74,7 +75,7 @@ if MYPY_RUNNING:
         from distutils.core import Distribution
 
     TRequirement = TypeVar("TRequirement")
-    RequirementType = TypeVar("RequirementType", covariant=True, bound=Requirement)
+    RequirementType = TypeVar("RequirementType", covariant=True, bound=PackagingRequirement)
     MarkerType = TypeVar("MarkerType", covariant=True, bound=Marker)
     STRING_TYPE = Union[str, bytes, Text]
     S = TypeVar("S", bytes, str, Text)

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -6,7 +6,9 @@ import os
 import shutil
 import sys
 from collections.abc import Iterable, Mapping
+from contextlib import ExitStack
 from functools import lru_cache
+from os import scandir
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse, urlunparse
 from weakref import finalize
@@ -15,13 +17,17 @@ import attr
 import pep517.envbuild
 import pep517.wrappers
 from distlib.wheel import Wheel
-from pip._vendor.packaging.markers import Marker
-from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.version import parse
 from pip._internal.network.download import Downloader
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.urls import url_to_path
-from pip._vendor.pkg_resources import Requirement, find_distributions, distributions_from_metadata
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.specifiers import SpecifierSet
+from pip._vendor.packaging.version import parse
+from pip._vendor.pkg_resources import (
+    Requirement,
+    distributions_from_metadata,
+    find_distributions,
+)
 from platformdirs import user_cache_dir
 from vistir.contextmanagers import cd, temp_path
 from vistir.misc import run
@@ -39,10 +45,6 @@ from .utils import (
     split_vcs_method_from_uri,
     strip_extras_markers_from_requirement,
 )
-
-
-from contextlib import ExitStack
-from os import scandir
 
 if MYPY_RUNNING:
     from typing import (
@@ -62,8 +64,12 @@ if MYPY_RUNNING:
 
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.req.req_install import InstallRequirement
+    from pip._vendor.pkg_resources import (
+        DistInfoDistribution,
+        EggInfoDistribution,
+        PathMetadata,
+    )
     from pip._vendor.requests import Session
-    from pip._vendor.pkg_resources import DistInfoDistribution, EggInfoDistribution, PathMetadata
 
     try:
         from setuptools.dist import Distribution
@@ -71,9 +77,7 @@ if MYPY_RUNNING:
         from distutils.core import Distribution
 
     TRequirement = TypeVar("TRequirement")
-    RequirementType = TypeVar(
-        "RequirementType", covariant=True, bound=Requirement
-    )
+    RequirementType = TypeVar("RequirementType", covariant=True, bound=Requirement)
     MarkerType = TypeVar("MarkerType", covariant=True, bound=Marker)
     STRING_TYPE = Union[str, bytes, Text]
     S = TypeVar("S", bytes, str, Text)

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -75,7 +75,9 @@ if MYPY_RUNNING:
         from distutils.core import Distribution
 
     TRequirement = TypeVar("TRequirement")
-    RequirementType = TypeVar("RequirementType", covariant=True, bound=PackagingRequirement)
+    RequirementType = TypeVar(
+        "RequirementType", covariant=True, bound=PackagingRequirement
+    )
     MarkerType = TypeVar("MarkerType", covariant=True, bound=Marker)
     STRING_TYPE = Union[str, bytes, Text]
     S = TypeVar("S", bytes, str, Text)

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -65,10 +65,7 @@ if MYPY_RUNNING:
 
     from pip._internal.index.package_finder import PackageFinder
     from pip._internal.req.req_install import InstallRequirement
-    from pip._vendor.pkg_resources import (
-        DistInfoDistribution,
-        EggInfoDistribution,
-    )
+    from pip._vendor.pkg_resources import DistInfoDistribution, EggInfoDistribution
     from pip._vendor.requests import Session
 
     try:

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -14,8 +14,7 @@ from urllib.parse import parse_qs, urlparse, urlunparse
 from weakref import finalize
 
 import attr
-import pep517.envbuild
-import pep517.wrappers
+from pep517 import envbuild, wrappers
 from distlib.wheel import Wheel
 from pip._internal.network.download import Downloader
 from pip._internal.utils.temp_dir import global_tempdir_manager
@@ -111,7 +110,7 @@ def pep517_subprocess_runner(cmd, cwd=None, extra_environ=None):
     )
 
 
-class BuildEnv(pep517.envbuild.BuildEnvironment):
+class BuildEnv(envbuild.BuildEnvironment):
     def pip_install(self, reqs):
         cmd = [
             sys.executable,
@@ -132,7 +131,7 @@ class BuildEnv(pep517.envbuild.BuildEnvironment):
         )
 
 
-class HookCaller(pep517.wrappers.Pep517HookCaller):
+class HookCaller(wrappers.Pep517HookCaller):
     def __init__(self, source_dir, build_backend, backend_path=None):
         super().__init__(source_dir, build_backend, backend_path=backend_path)
         self.source_dir = os.path.abspath(source_dir)
@@ -140,7 +139,7 @@ class HookCaller(pep517.wrappers.Pep517HookCaller):
         self._subprocess_runner = pep517_subprocess_runner
         if backend_path:
             backend_path = [
-                pep517.wrappers.norm_and_check(self.source_dir, p) for p in backend_path
+                wrappers.norm_and_check(self.source_dir, p) for p in backend_path
             ]
         self.backend_path = backend_path
 

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -21,11 +21,11 @@ from pip._internal.network.download import Downloader
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.urls import url_to_path
 from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.requirements import Requirement
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.version import parse
 from pip._vendor.pkg_resources import (
     PathMetadata,
-    Requirement,
     distributions_from_metadata,
     find_distributions,
 )

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -24,6 +24,7 @@ from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.version import parse
 from pip._vendor.pkg_resources import (
+    PathMetadata,
     Requirement,
     distributions_from_metadata,
     find_distributions,
@@ -67,7 +68,6 @@ if MYPY_RUNNING:
     from pip._vendor.pkg_resources import (
         DistInfoDistribution,
         EggInfoDistribution,
-        PathMetadata,
     )
     from pip._vendor.requests import Session
 

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -14,8 +14,8 @@ from urllib.parse import parse_qs, urlparse, urlunparse
 from weakref import finalize
 
 import attr
-from pep517 import envbuild, wrappers
 from distlib.wheel import Wheel
+from pep517 import envbuild, wrappers
 from pip._internal.network.download import Downloader
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.urls import url_to_path

--- a/src/requirementslib/models/url.py
+++ b/src/requirementslib/models/url.py
@@ -1,6 +1,3 @@
-# -*- coding=utf-8 -*-
-from __future__ import absolute_import, print_function
-
 from urllib.parse import quote
 from urllib.parse import unquote as url_unquote
 from urllib.parse import unquote_plus

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -518,10 +518,7 @@ def split_markers_from_line(line):
     )
     if line_quote and line.endswith(line_quote):
         line = line.strip(line_quote)
-    if not any(line.startswith(uri_prefix) for uri_prefix in SCHEME_LIST):
-        marker_sep = ";"
-    else:
-        marker_sep = "; "
+    marker_sep = " ; "
     markers = None
     if marker_sep in line:
         line, markers = line.split(marker_sep, 1)
@@ -636,7 +633,7 @@ def _requirement_to_str_lowercase_name(requirement):
         parts.append("@ {0}".format(requirement.url))
 
     if requirement.marker:
-        parts.append("; {0}".format(requirement.marker))
+        parts.append(" ; {0}".format(requirement.marker))
 
     return "".join(parts)
 
@@ -658,11 +655,11 @@ def format_requirement(ireq):
 
     if str(ireq.req.marker) != str(ireq.markers):
         if not ireq.req.marker:
-            line = "{}; {}".format(line, ireq.markers)
+            line = "{} ; {}".format(line, ireq.markers)
         else:
             name, markers = line.split(";", 1)
             markers = markers.strip()
-            line = "{}; ({}) and ({})".format(name, markers, ireq.markers)
+            line = "{} ; ({}) and ({})".format(name, markers, ireq.markers)
 
     return line
 
@@ -868,7 +865,7 @@ def make_install_requirement(
     if version:
         requirement_string = "{0}=={1}".format(requirement_string, str(version))
     if markers:
-        requirement_string = "{0}; {1}".format(requirement_string, str(markers))
+        requirement_string = "{0} ; {1}".format(requirement_string, str(markers))
     return install_req_from_line(requirement_string, constraint=constraint)
 
 
@@ -942,7 +939,7 @@ def fix_requires_python_marker(requires_python):
                 for op, vals in spec_dict.items()
             ]
         )
-    marker_to_add = PackagingRequirement("fakepkg; {0}".format(marker_str)).marker
+    marker_to_add = PackagingRequirement("fakepkg ; {0}".format(marker_str)).marker
     return marker_to_add
 
 

--- a/src/requirementslib/models/utils.py
+++ b/src/requirementslib/models/utils.py
@@ -9,13 +9,13 @@ from pathlib import Path
 
 import tomlkit
 from attr import validators
+from pip._internal.models.link import Link
+from pip._internal.req.constructors import install_req_from_line
 from pip._vendor.packaging.markers import InvalidMarker, Marker, Op, Value, Variable
+from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
 from pip._vendor.packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import parse as parse_version
-from pip._internal.models.link import Link
-from pip._internal.req.constructors import install_req_from_line
-from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
 from pip._vendor.pkg_resources import Requirement, get_distribution, safe_name
 from plette.models import Package, PackageCollection
 from tomlkit.container import Container

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -17,7 +17,7 @@ from vistir.path import ensure_mkdir_p, is_valid_url
 from .environment import MYPY_RUNNING
 
 if MYPY_RUNNING:
-    from typing import Any, Dict, Iterable, List, Optional, Text, Tuple, TypeVar, Union
+    from typing import Dict, List, Optional, Text, Tuple, TypeVar, Union
 
     STRING_TYPE = Union[bytes, str, Text]
     S = TypeVar("S", bytes, str, Text)

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -1,6 +1,3 @@
-# -*- coding=utf-8 -*-
-from __future__ import absolute_import, print_function
-
 import logging
 import os
 import sys
@@ -14,6 +11,7 @@ from pip._internal.commands.install import InstallCommand
 from pip._internal.models.target_python import TargetPython
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import is_installable_dir
+from pip._vendor.packaging import specifiers
 from vistir.path import ensure_mkdir_p, is_valid_url
 
 from .environment import MYPY_RUNNING
@@ -159,7 +157,6 @@ def convert_entry_to_path(path):
 def is_installable_file(path):
     # type: (PipfileType) -> bool
     """Determine if a path can potentially be installed."""
-    from packaging import specifiers
 
     if isinstance(path, Mapping):
         path = convert_entry_to_path(path)
@@ -203,9 +200,9 @@ def is_installable_file(path):
 def get_dist_metadata(dist):
     from email.parser import FeedParser
 
-    import pkg_resources
+    from pip._vendor.pkg_resources import DistInfoDistribution
 
-    if isinstance(dist, pkg_resources.DistInfoDistribution) and dist.has_metadata(
+    if isinstance(dist, DistInfoDistribution) and dist.has_metadata(
         "METADATA"
     ):
         metadata = dist.get_metadata("METADATA")

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -202,9 +202,7 @@ def get_dist_metadata(dist):
 
     from pip._vendor.pkg_resources import DistInfoDistribution
 
-    if isinstance(dist, DistInfoDistribution) and dist.has_metadata(
-        "METADATA"
-    ):
+    if isinstance(dist, DistInfoDistribution) and dist.has_metadata("METADATA"):
         metadata = dist.get_metadata("METADATA")
     elif dist.has_metadata("PKG-INFO"):
         metadata = dist.get_metadata("PKG-INFO")

--- a/tests/unit/strategies.py
+++ b/tests/unit/strategies.py
@@ -288,7 +288,8 @@ sample_values = sorted(
         "linux2",
         "darwin",
         "win32",
-        "java1.8.0_51" "x86_64",  # sys.platform
+        "java1.8.0_51",
+        "x86_64",  # sys.platform
         "i386",  # platform.machine
         "CPython",
         "Jython",
@@ -459,7 +460,7 @@ def repository_line(draw, repositories=repository_url(), markers=random_marker_s
     marker_selection = draw(markers)
     marker_str = ""
     if marker_selection:
-        marker_str = " ; {0}".format(marker_selection)
+        marker_str = "; {0}".format(marker_selection)
     if prefix:
         line = ""
     line = "{0}{1}{2}".format(prefix, draw(repositories), marker_str)

--- a/tests/unit/strategies.py
+++ b/tests/unit/strategies.py
@@ -459,7 +459,7 @@ def repository_line(draw, repositories=repository_url(), markers=random_marker_s
     marker_selection = draw(markers)
     marker_str = ""
     if marker_selection:
-        marker_str = "; {0}".format(marker_selection)
+        marker_str = " ; {0}".format(marker_selection)
     if prefix:
         line = ""
     line = "{0}{1}{2}".format(prefix, draw(repositories), marker_str)
@@ -533,7 +533,7 @@ def requirements(
     marker_str = ""
     if marker_selection:
         marker_str = "; {0}".format(marker_selection)
-        line = "{0}{1}".format(line, marker_str)
+        line = "{0} {1}".format(line, marker_str)
         as_list = ["{0}".format(line)]
     if hashes_option:
         hashes_list = sorted(set(hashes_option))

--- a/tests/unit/strategies.py
+++ b/tests/unit/strategies.py
@@ -9,13 +9,11 @@ from collections import namedtuple
 from urllib import parse as urllib_parse
 
 import vistir
-from hypothesis import assume
 from hypothesis import strategies as st
 from hypothesis.provisional import URL_SAFE_CHARACTERS, domains
-from hypothesis.provisional import urls as url_strategy
-from packaging.markers import MARKER_OP, VARIABLE
-from packaging.specifiers import Specifier
-from packaging.version import parse as parse_version
+from pip._vendor.packaging.markers import MARKER_OP, VARIABLE
+from pip._vendor.packaging.specifiers import Specifier
+from pip._vendor.packaging.version import parse as parse_version
 from pyparsing import Literal, MatchFirst, ParseExpression, ParserElement
 
 from requirementslib.models.url import URI

--- a/tests/unit/strategies.py
+++ b/tests/unit/strategies.py
@@ -1,4 +1,3 @@
-# -*- coding=utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os
@@ -9,12 +8,13 @@ from collections import namedtuple
 from urllib import parse as urllib_parse
 
 import vistir
+from hypothesis import assume
 from hypothesis import strategies as st
 from hypothesis.provisional import URL_SAFE_CHARACTERS, domains
 from pip._vendor.packaging.markers import MARKER_OP, VARIABLE
 from pip._vendor.packaging.specifiers import Specifier
 from pip._vendor.packaging.version import parse as parse_version
-from pyparsing import Literal, MatchFirst, ParseExpression, ParserElement
+from pip._vendor.pyparsing import Literal, MatchFirst, ParseExpression, ParserElement
 
 from requirementslib.models.url import URI
 

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,11 +1,10 @@
 import pytest
-from packaging.specifiers import Specifier, SpecifierSet
+from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
 )
 
-import requirementslib
 from requirementslib.models.dependencies import (
     AbstractDependency,
     get_abstract_dependencies,

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,9 +1,9 @@
 import pytest
-from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._internal.req.constructors import (
     install_req_from_editable,
     install_req_from_line,
 )
+from pip._vendor.packaging.specifiers import SpecifierSet
 
 from requirementslib.models.dependencies import (
     AbstractDependency,

--- a/tests/unit/test_markers.py
+++ b/tests/unit/test_markers.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 import pytest
-from packaging.markers import Marker
-from packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
-from packaging.version import Version
+from pip._vendor.packaging.markers import Marker
+from pip._vendor.packaging.specifiers import InvalidSpecifier, Specifier, SpecifierSet
+from pip._vendor.packaging.version import Version
 
 import requirementslib.models.markers
 

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -332,7 +332,7 @@ def test_get_requirements(monkeypatch_if_needed):
     assert spec.name == "tablib" and spec.specs == [("==", "0.12.1")]
     # Test complex package with both extras and markers
     extras_markers = Requirement.from_line(
-        "requests[security]; os_name=='posix'"
+        "requests[security] ; os_name=='posix'"
     ).requirement
     assert list(extras_markers.extras) == ["security"]
     assert extras_markers.name == "requests"

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -177,7 +177,6 @@ def test_repo_line(repo_line):
             reformatted_line = "{0} {1}".format(repo_list[0], repo_list[1])
     else:
         repo_list = [repo_line]
-    line_as_list = repo_line.split(" ", 1) if repo_line.startswith("-e ") else [repo_line]
     assert (
         Line(repo_line).get_line(with_prefix=True, with_markers=True, as_list=False)
         == reformatted_line

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -174,7 +174,7 @@ def test_repo_line(repo_line):
     if repo_line.startswith("-e "):
         repo_list = repo_line.split(" ", 1)
         if "; " in repo_list[1]:
-            reformatted_line = '{0} "{1}"'.format(repo_list[0], repo_list[1])
+            reformatted_line = "{0} {1}".format(repo_list[0], repo_list[1])
     else:
         repo_list = [repo_line]
     line_as_list = repo_line.split(" ", 1) if repo_line.startswith("-e ") else [repo_line]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -65,7 +65,7 @@ def test_strip_ssh_from_git_url():
 
 
 def test_split_markers_from_line():
-    line = "test_requirement; marker=='something'"
+    line = "test_requirement ; marker=='something'"
     assert utils.split_markers_from_line(line) == (
         "test_requirement",
         "marker=='something'",


### PR DESCRIPTION
This opens the door to rewriting all of the pkg_resources imports in pipenv to come from `pip._vendor.pkg_resources` -- If I do this now in pipenv it breaks vcs dependency requirements because it imports from an incompatible path in some places in requirements.   The nice thing, is by heading in this direction, it has eliminated these style warnings for me locally which we also get a lot of reports about:  https://github.com/pypa/pipenv/issues/5208

Additionally this should help with: https://github.com/pypa/pipenv/issues/5349

This also fixes the issue where tests were not passing with the latest version of pyparsing.

Fixes #181 

This was realized when I re-wrote the imports here and it broke 3 vcs related tests: https://github.com/pypa/pipenv/pull/5350

Note about the spaces before the ; -- https://github.com/pypa/packaging/issues/529