### PR TITLE
Remove vistir mkdir p

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,13 +12,13 @@ INIT_PY = PACKAGE_ROOT / "__init__.py"
 @nox.session
 def tests(session: nox.Session):
     session.install("-e", ".[tests]")
-    session.run("pytest", "-ra", "tests")
+    session.run("pytest", "-ra", "-x", "-v", "tests")
 
 
 @nox.session
 def coverage(session: nox.Session):
     session.install(".[tests]", "coveralls")
-    session.run("pytest", "--cov=requirementslib", "-ra", "tests")
+    session.run("pytest", "--cov=requirementslib", "-x", "-v", "-ra", "tests")
     session.run("coveralls")
 
 

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -563,7 +563,7 @@ def get_pip_options(args=None, sources=None, pip_command=None):
         pip_command = get_pip_command()
     if not sources:
         sources = [{"url": "https://pypi.org/simple", "name": "pypi", "verify_ssl": True}]
-    os.makedirs(CACHE_DIR, mode=0o777)
+    os.makedirs(CACHE_DIR, mode=0o777, exist_ok=True)
     pip_args = args or []
     pip_args = prepare_pip_source_args(sources, pip_args)
     pip_options, _ = pip_command.parser.parse_args(pip_args)

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -23,7 +23,6 @@ from vistir.path import create_tracked_tempdir
 
 from ..environment import MYPY_RUNNING
 from ..utils import (
-    _ensure_dir,
     get_package_finder,
     get_pip_command,
     prepare_pip_source_args,
@@ -564,7 +563,7 @@ def get_pip_options(args=None, sources=None, pip_command=None):
         pip_command = get_pip_command()
     if not sources:
         sources = [{"url": "https://pypi.org/simple", "name": "pypi", "verify_ssl": True}]
-    _ensure_dir(CACHE_DIR)
+    os.makedirs(CACHE_DIR, mode=0o777)
     pip_args = args or []
     pip_args = prepare_pip_source_args(sources, pip_args)
     pip_options, _ = pip_command.parser.parse_args(pip_args)
@@ -620,7 +619,7 @@ def start_resolver(finder=None, session=None, wheel_cache=None):
         session = pip_command._build_session(pip_options)
 
     download_dir = PKGS_DOWNLOAD_DIR
-    _ensure_dir(download_dir)
+    os.makedir(download_dir, mode=0o777)
 
     _build_dir = create_tracked_tempdir(fs_str("build"))
     _source_dir = create_tracked_tempdir(fs_str("source"))
@@ -629,7 +628,7 @@ def start_resolver(finder=None, session=None, wheel_cache=None):
         with global_tempdir_manager(), get_build_tracker() as build_tracker:
             if not wheel_cache:
                 wheel_cache = _get_wheel_cache()
-            _ensure_dir(str(os.path.join(wheel_cache.cache_dir, "wheels")))
+            os.makdirs(os.path.join(wheel_cache.cache_dir, "wheels"))
             preparer = pip_command.make_requirement_preparer(
                 temp_build_dir=_build_dir,
                 options=pip_options,

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -22,11 +22,7 @@ from vistir.contextmanagers import temp_environ
 from vistir.path import create_tracked_tempdir
 
 from ..environment import MYPY_RUNNING
-from ..utils import (
-    get_package_finder,
-    get_pip_command,
-    prepare_pip_source_args,
-)
+from ..utils import get_package_finder, get_pip_command, prepare_pip_source_args
 from .cache import CACHE_DIR, DependencyCache
 from .setup_info import SetupInfo
 from .utils import (

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2122,7 +2122,7 @@ class VCSRequirement(FileRequirement):
                 return checkout_dir
         if src_dir is not None:
             checkout_dir = os.path.join(os.path.abspath(src_dir), self.name)
-            os.makedirs(src_dir)
+            os.makedirs(src_dir, exist_ok=True)
             return checkout_dir
         return os.path.join(create_tracked_tempdir(prefix="requirementslib"), self.name)
 

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -38,7 +38,6 @@ from vistir.path import (
     get_converted_relative_path,
     is_file_url,
     is_valid_url,
-    mkdir_p,
     normalize_path,
 )
 
@@ -2123,7 +2122,7 @@ class VCSRequirement(FileRequirement):
                 return checkout_dir
         if src_dir is not None:
             checkout_dir = os.path.join(os.path.abspath(src_dir), self.name)
-            mkdir_p(src_dir)
+            os.makedirs(src_dir)
             return checkout_dir
         return os.path.join(create_tracked_tempdir(prefix="requirementslib"), self.name)
 

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -31,7 +31,7 @@ from pip._vendor.pkg_resources import (
 from platformdirs import user_cache_dir
 from vistir.contextmanagers import cd, temp_path
 from vistir.misc import run
-from vistir.path import create_tracked_tempdir, ensure_mkdir_p, mkdir_p, rmtree
+from vistir.path import create_tracked_tempdir, rmtree
 
 from ..environment import MYPY_RUNNING
 from ..exceptions import RequirementError
@@ -559,7 +559,6 @@ def build_pep517(source_dir, build_dir, config_settings=None, dist_type="wheel")
         return build_fn(build_dir, config_settings)
 
 
-@ensure_mkdir_p(mode=0o775)
 def _get_src_dir(root):
     # type: (AnyStr) -> AnyStr
     src = os.environ.get("PIP_SRC")
@@ -573,6 +572,8 @@ def _get_src_dir(root):
         src_dir = create_tracked_tempdir(prefix="requirementslib-", suffix="-src")
     else:
         src_dir = os.path.join(root, "src")
+
+    os.makedirs(src_dir, mode=0o775)
     return src_dir
 
 
@@ -613,10 +614,10 @@ def _prepare_wheel_building_kwargs(
 ):
     # type: (...) -> Dict[STRING_TYPE, STRING_TYPE]
     download_dir = os.path.join(CACHE_DIR, "pkgs")  # type: STRING_TYPE
-    mkdir_p(download_dir)
+    os.path.makedirs(download_dir, exist_ok=False)
 
     wheel_download_dir = os.path.join(CACHE_DIR, "wheels")  # type: STRING_TYPE
-    mkdir_p(wheel_download_dir)
+    os.makedirs(wheel_download_dir)
     if src_dir is None:
         if editable and src_root is not None:
             src_dir = src_root

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -614,10 +614,10 @@ def _prepare_wheel_building_kwargs(
 ):
     # type: (...) -> Dict[STRING_TYPE, STRING_TYPE]
     download_dir = os.path.join(CACHE_DIR, "pkgs")  # type: STRING_TYPE
-    os.path.makedirs(download_dir, exist_ok=False)
+    os.makedirs(download_dir, exist_ok=True)
 
     wheel_download_dir = os.path.join(CACHE_DIR, "wheels")  # type: STRING_TYPE
-    os.makedirs(wheel_download_dir)
+    os.makedirs(wheel_download_dir, exist_ok=True)
     if src_dir is None:
         if editable and src_root is not None:
             src_dir = src_root

--- a/src/requirementslib/utils.py
+++ b/src/requirementslib/utils.py
@@ -12,7 +12,7 @@ from pip._internal.models.target_python import TargetPython
 from pip._internal.utils.filetypes import is_archive_file
 from pip._internal.utils.misc import is_installable_dir
 from pip._vendor.packaging import specifiers
-from vistir.path import ensure_mkdir_p, is_valid_url
+from vistir.path import is_valid_url
 
 from .environment import MYPY_RUNNING
 
@@ -290,11 +290,6 @@ def get_package_finder(
         target_python=target_python,
         ignore_requires_python=ignore_requires_python,
     )
-
-
-@ensure_mkdir_p(mode=0o777)
-def _ensure_dir(path):
-    return path
 
 
 _UNSET = object()


### PR DESCRIPTION
As part of cleaning pipenv's dependency on vistir, there is also a need to clean up requirementslib.
These changes do not change any functionality and remove vistir usage in favour of the std library.