### PR TITLE
Bump version of vistir dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     requests
     setuptools>=40.8
     tomlkit>=0.5.3
-    vistir==0.6.1
+    vistir==0.7.0
 
 [options.extras_require]
 tests =

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -17,7 +17,6 @@ from pip._internal.utils.temp_dir import TempDirectory, global_tempdir_manager
 from pip._vendor.packaging.markers import Marker
 from pip._vendor.packaging.utils import canonicalize_name
 from pip._vendor.packaging.version import parse
-from vistir.compat import fs_str
 from vistir.contextmanagers import temp_environ
 from vistir.path import create_tracked_tempdir
 
@@ -53,8 +52,8 @@ if MYPY_RUNNING:
     S = TypeVar("S", bytes, str, Text)
 
 
-PKGS_DOWNLOAD_DIR = fs_str(os.path.join(CACHE_DIR, "pkgs"))
-WHEEL_DOWNLOAD_DIR = fs_str(os.path.join(CACHE_DIR, "wheels"))
+PKGS_DOWNLOAD_DIR = os.path.join(CACHE_DIR, "pkgs")
+WHEEL_DOWNLOAD_DIR = os.path.join(CACHE_DIR, "wheels")
 
 DEPENDENCY_CACHE = DependencyCache()
 
@@ -617,8 +616,8 @@ def start_resolver(finder=None, session=None, wheel_cache=None):
     download_dir = PKGS_DOWNLOAD_DIR
     os.makedir(download_dir, mode=0o777)
 
-    _build_dir = create_tracked_tempdir(fs_str("build"))
-    _source_dir = create_tracked_tempdir(fs_str("source"))
+    _build_dir = create_tracked_tempdir("build")
+    _source_dir = create_tracked_tempdir("source")
     pip_options.src_dir = _source_dir
     try:
         with global_tempdir_manager(), get_build_tracker() as build_tracker:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 # -*- coding=utf-8 -*-
-from __future__ import absolute_import, print_function
 
 import contextlib
 import io
@@ -101,7 +100,7 @@ def pip_src_dir(request, pathlib_tmpdir):
     os.environ["PIP_SRC"] = pathlib_tmpdir.as_posix()
 
     def finalize():
-        os.environ["PIP_SRC"] = vistir.compat.fs_str(old_src_dir)
+        os.environ["PIP_SRC"] = old_src_dir
 
     request.addfinalizer(finalize)
     return request

--- a/tests/unit/test_setup_info.py
+++ b/tests/unit/test_setup_info.py
@@ -1,6 +1,7 @@
 # -*- coding=utf-8 -*-
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 import vistir
@@ -73,7 +74,7 @@ def test_remote_source_in_subdirectory(url_line, name):
 def test_no_duplicate_egg_info():
     """When the package has 'src' directory, do not write egg-info in base
     dir."""
-    base_dir = vistir.compat.Path(os.path.abspath(os.getcwd())).as_posix()
+    base_dir = Path(os.path.abspath(os.getcwd())).as_posix()
     r = Requirement.from_line("-e {}".format(base_dir))
     egg_info_name = "{}.egg-info".format(r.name.replace("-", "_"))
     distinfo_name = "{0}.dist-info".format(r.name.replace("-", "_"))


### PR DESCRIPTION
As vistir dropped the compat module, it's usage was also removed here.