### PR TITLE
Don't use the deprecated Python distutils module

### DIFF
--- a/news/348.trival.rst
+++ b/news/348.trival.rst
@@ -1,0 +1,1 @@
+Don't use the deprecated Python distutils module

--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -3,9 +3,9 @@ import copy
 import os
 import sys
 from contextlib import contextmanager
-from distutils.sysconfig import get_python_lib
 from functools import lru_cache
 from pathlib import Path
+from sysconfig import get_path
 from urllib import parse as urllib_parse
 from urllib.parse import unquote
 
@@ -899,7 +899,7 @@ class Line(object):
         wheel_kwargs["src_dir"] = repo.checkout_directory
         with global_tempdir_manager(), temp_path():
             ireq.ensure_has_source_dir(wheel_kwargs["src_dir"])
-            sys.path = [repo.checkout_directory, "", ".", get_python_lib(plat_specific=0)]
+            sys.path = [repo.checkout_directory, "", ".", get_path("purelib")]
             setupinfo = SetupInfo.create(
                 repo.checkout_directory,
                 ireq=ireq,

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -67,11 +67,7 @@ if MYPY_RUNNING:
     from pip._vendor.packaging.requirements import Requirement as PackagingRequirement
     from pip._vendor.pkg_resources import DistInfoDistribution, EggInfoDistribution
     from pip._vendor.requests import Session
-
-    try:
-        from setuptools.dist import Distribution
-    except ImportError:
-        from distutils.core import Distribution
+    from setuptools.dist import Distribution
 
     TRequirement = TypeVar("TRequirement")
     RequirementType = TypeVar(


### PR DESCRIPTION
The Python standard library distutils module will be removed from Python 3.12+

https://peps.python.org/pep-0632/

The package already has setuptools in install_requires, so no need to try-except import it.