### PR TITLE
Remove usage of vistir.misc.dedup

### DIFF
--- a/news/349.trivial.rst
+++ b/news/349.trivial.rst
@@ -1,0 +1,1 @@
+Replace usage of vistir.misc.dedup with a simple one liner.

--- a/src/requirementslib/models/markers.py
+++ b/src/requirementslib/models/markers.py
@@ -9,7 +9,6 @@ from distlib import markers
 from pip._vendor.packaging.markers import InvalidMarker, Marker
 from pip._vendor.packaging.specifiers import LegacySpecifier, Specifier, SpecifierSet
 from pip._vendor.packaging.version import parse
-from vistir.misc import dedup
 
 from ..environment import MYPY_RUNNING
 from ..exceptions import RequirementError
@@ -292,7 +291,7 @@ def cleanup_pyspecs(specs, joiner="or"):
     for op_and_version_type, versions in _group_by_op(tuple(specs)):
         op = op_and_version_type[0]
         versions = [version[1] for version in versions]
-        versions = sorted(dedup(versions))
+        versions = sorted(iter(dict.fromkeys(versions)))
         op_key = next(iter(k for k in translation_keys if op in k), None)
         version_value = versions
         if op_key is not None:

--- a/src/requirementslib/models/markers.py
+++ b/src/requirementslib/models/markers.py
@@ -291,7 +291,7 @@ def cleanup_pyspecs(specs, joiner="or"):
     for op_and_version_type, versions in _group_by_op(tuple(specs)):
         op = op_and_version_type[0]
         versions = [version[1] for version in versions]
-        versions = sorted(iter(dict.fromkeys(versions)))
+        versions = sorted(dict.fromkeys(versions))  # remove duplicate entries
         op_key = next(iter(k for k in translation_keys if op in k), None)
         version_value = versions
         if op_key is not None:


### PR DESCRIPTION
Python dictionaries are sorted since 3.6. No need for a special function for this.

Vistir will deprecated this function in the near future.