### PR TITLE
Fix regression discovered for eggs from URL

### DIFF
--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -2526,7 +2526,7 @@ class Requirement(object):
                 and not local_editable
                 and not self.req.get_uri().startswith("file://")
             ):
-                line_parts.append(f"#egg={self.extras_as_pip}")
+                line_parts.append(f"#egg={self._name}{self.extras_as_pip}")
             else:
                 line_parts.append(self.extras_as_pip)
         if self._specifiers and not (self.is_file_or_url or self.is_vcs):

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -59,12 +59,12 @@ DEP_PIP_PAIRS = [
     (
         # Extras in url
         {
-            "discord.py": {
-                "file": "https://github.com/Rapptz/discord.py/archive/async.zip",
-                "extras": ["voice"],
+            "dparse": {
+                "file": "https://github.com/oz123/dparse/archive/refs/heads/master.zip",
+                "extras": ["pipenv"],
             }
         },
-        "https://github.com/Rapptz/discord.py/archive/async.zip#egg=discord.py[voice]",
+        "https://github.com/oz123/dparse/archive/refs/heads/master.zip#egg=dparse[pipenv]"
     ),
     (
         {

--- a/tests/unit/test_requirements.py
+++ b/tests/unit/test_requirements.py
@@ -64,7 +64,7 @@ DEP_PIP_PAIRS = [
                 "extras": ["pipenv"],
             }
         },
-        "https://github.com/oz123/dparse/archive/refs/heads/master.zip#egg=dparse[pipenv]"
+        "https://github.com/oz123/dparse/archive/refs/heads/master.zip#egg=dparse[pipenv]",
     ),
     (
         {


### PR DESCRIPTION
If one has the following dependencies

            "dparse": {
                "file": "https://github.com/oz123/dparse/archive/refs/heads/master.zip",
                "extras": ["pipenv"],
             }

The code before this commit will produce:

```
['https://github.com/oz123/dparse/archive/refs/heads/master.zip', '#egg=[pipenv]']
```

Where I believe it should produce:

```
https://github.com/oz123/dparse/archive/refs/heads/master.zip', '#egg=dparse[pipenv]']
```