### PR TITLE
requirements parsing: do not include egg name twice

### DIFF
--- a/src/requirementslib/models/requirements.py
+++ b/src/requirementslib/models/requirements.py
@@ -1831,7 +1831,7 @@ class FileRequirement(object):
                 line = "{0}&subdirectory={1}".format(line, pipfile["subdirectory"])
         if editable:
             line = "-e {0}".format(line)
-        arg_dict["parsed_line"] = Line(line)
+        arg_dict["parsed_line"] = Line(line, extras=extras)
         arg_dict["setup_info"] = arg_dict["parsed_line"].setup_info
         return cls(**arg_dict)  # type: ignore
 
@@ -2525,6 +2525,8 @@ class Requirement(object):
                 self.is_file_or_url
                 and not local_editable
                 and not self.req.get_uri().startswith("file://")
+                # fix for file uri with egg names and extras
+                and not len(self.req.line_part.split("#")) > 1
             ):
                 line_parts.append(f"#egg={self._name}{self.extras_as_pip}")
             else:


### PR DESCRIPTION
Requirements with a wheel path with extras caused a constraint line with egg name which was included twice.
For example:

```
'spacy = {file = "https://files.pythonhosted.org/packages/.../spacy-3.4.3-cp39-..._x86_64.whl", extras = ["transformers"]}'
```

Produced a constraint line like the following:
```
https://files.pythonhosted.org/.../spacy-3.4.3-..._x86_64.whl#egg=spacy#egg=spacy[transformers]
```

This line triggered an unhandled excpetion `pipenv.exceptions.ResolutionFailure`, as in https://github.com/pypa/pipenv/issues/5536.

