### PR TITLE
Remove old_unpack_url

### DIFF
--- a/src/requirementslib/models/old_pip_utils.py
+++ b/src/requirementslib/models/old_pip_utils.py
@@ -11,32 +11,19 @@ import os
 import shutil
 import stat
 
-from vistir.path import rmtree
-
 logger = logging.getLogger(__name__)
 
 
-from typing import Dict, Iterable, List, Optional
-
-from pip._internal.models.link import Link
-from pip._internal.network.download import Downloader
-from pip._internal.operations.prepare import (
-    File,
-    get_file_url,
-    get_http_url,
-    unpack_vcs_link,
-)
-from pip._internal.utils.hashes import Hashes
-from pip._internal.utils.unpacking import unpack_file
+from typing import Dict, Iterable, List
 
 
-def is_socket(path):
-    # type: (str) -> bool
+# This can be removed once this pr is merged
+# https://github.com/python/cpython/pull/16575
+def is_socket(path: str) -> bool:
     return stat.S_ISSOCK(os.lstat(path).st_mode)
 
 
-def copy2_fixed(src, dest):
-    # type: (str, str) -> None
+def copy2_fixed(src: str, dest: str) -> None:
     """Wrap shutil.copy2() but map errors copying socket files to
     SpecialFileError as expected.
 
@@ -108,55 +95,3 @@ def _copy_source_tree(source: str, target: str) -> None:
         symlinks=True,
         copy_function=_copy2_ignoring_special_files,
     )
-
-
-def old_unpack_url(
-    link: Link,
-    location: str,
-    download: Downloader,
-    verbosity: int,
-    download_dir: Optional[str] = None,
-    hashes: Optional[Hashes] = None,
-) -> Optional[File]:
-    """Unpack link into location, downloading if required.
-
-    :param hashes: A Hashes object, one of whose embedded hashes must match,
-        or HashMismatch will be raised. If the Hashes is empty, no matches are
-        required, and unhashable types of requirements (like VCS ones, which
-        would ordinarily raise HashUnsupported) are allowed.
-    """
-    # non-editable vcs urls
-    if link.is_vcs:
-        unpack_vcs_link(link, location, verbosity=verbosity)
-        return None
-
-    # Once out-of-tree-builds are no longer supported, could potentially
-    # replace the below condition with `assert not link.is_existing_dir`
-    # - unpack_url does not need to be called for in-tree-builds.
-    #
-    # As further cleanup, _copy_source_tree and accompanying tests can
-    # be removed.
-    #
-    # TODO when use-deprecated=out-of-tree-build is removed
-    if link.is_existing_dir():
-        if os.path.isdir(location):
-            rmtree(location)
-        _copy_source_tree(link.file_path, location)
-        return None
-
-    # file urls
-    if link.is_file:
-        file = get_file_url(link, download_dir, hashes=hashes)
-    # http urls
-    else:
-        file = get_http_url(
-            link,
-            download,
-            download_dir,
-            hashes=hashes,
-        )
-    # unpack the archive to the build dir location. even when only downloading
-    # archives, they have to be unpacked to parse dependencies, except wheels
-    if not link.is_wheel:
-        unpack_file(file.path, location, file.content_type)
-    return file

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -18,6 +18,7 @@ import attr
 from distlib.wheel import Wheel
 from pep517 import envbuild, wrappers
 from pip._internal.network.download import Downloader
+from pip._internal.operations.prepare import unpack_url
 from pip._internal.utils.temp_dir import global_tempdir_manager
 from pip._internal.utils.urls import url_to_path
 from pip._vendor.packaging.markers import Marker
@@ -36,7 +37,7 @@ from vistir.path import create_tracked_tempdir, rmtree
 from ..environment import MYPY_RUNNING
 from ..exceptions import RequirementError
 from ..utils import get_pip_command
-from .old_pip_utils import old_unpack_url
+from .old_pip_utils import _copy_source_tree
 from .utils import (
     get_default_pyproject_backend,
     get_name_variants,
@@ -1514,16 +1515,22 @@ build-backend = "{1}"
             build_location_func(**build_kwargs)
             ireq.ensure_has_source_dir(kwargs["src_dir"])
             location = None
-            if getattr(ireq, "source_dir", None):
+            if ireq.source_dir:
                 location = ireq.source_dir
-            old_unpack_url(
-                link=ireq.link,
-                location=location,
-                download=Downloader(session, "off"),
-                verbosity=1,
-                download_dir=download_dir,
-                hashes=ireq.hashes(True),
-            )
+
+            if ireq.link.is_existing_dir():
+                if os.path.isdir(location):
+                    rmtree(location)
+                _copy_source_tree(ireq.link.file_path, location)
+            else:
+                unpack_url(
+                    link=ireq.link,
+                    location=location,
+                    download=Downloader(session, "off"),
+                    verbosity=1,
+                    download_dir=download_dir,
+                    hashes=ireq.hashes(True),
+                )
         created = cls.create(
             ireq.source_dir, subdirectory=subdir, ireq=ireq, kwargs=kwargs, stack=stack
         )


### PR DESCRIPTION
The alternative is to use the new function from pip, with the removal of the source directry, which was done before.