### PR TITLE
Compatibility changes for Pip 23.1

### DIFF
--- a/news/363.vendor.rst
+++ b/news/363.vendor.rst
@@ -1,0 +1,1 @@
+Update ``WheelCache`` usage to be compatible with ``pip==23.1``

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     cached_property
     distlib>=0.2.8
     pep517>=0.5.0
-    pip>=22.2
+    pip>=23.1
     platformdirs
     plette[validation]
     requests

--- a/src/requirementslib/models/dependencies.py
+++ b/src/requirementslib/models/dependencies.py
@@ -8,7 +8,6 @@ from json import JSONDecodeError
 import attr
 import requests
 from pip._internal.cache import WheelCache
-from pip._internal.models.format_control import FormatControl
 from pip._internal.operations.build.build_tracker import get_build_tracker
 from pip._internal.req.constructors import install_req_from_line
 from pip._internal.req.req_install import InstallRequirement
@@ -61,7 +60,7 @@ DEPENDENCY_CACHE = DependencyCache()
 @contextlib.contextmanager
 def _get_wheel_cache():
     with global_tempdir_manager():
-        yield WheelCache(CACHE_DIR, FormatControl(set(), set()))
+        yield WheelCache(CACHE_DIR)
 
 
 def _get_filtered_versions(ireq, versions, prereleases):
@@ -446,7 +445,7 @@ def is_python(section):
 def get_resolver(
     finder, build_tracker, pip_options, session, directory, install_command=None
 ):
-    wheel_cache = WheelCache(pip_options.cache_dir, pip_options.format_control)
+    wheel_cache = WheelCache(pip_options.cache_dir)
     if install_command is None:
         install_command = get_pip_command()
     preparer = install_command.make_requirement_preparer(


### PR DESCRIPTION
These changes are already in pipenv, but we want to make them permanent so the vendoring re-run is consistent.