### PR TITLE
fix: parse setup.py when file has UTF-8 BOM

### DIFF
--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -158,7 +158,7 @@ class SetupReader:
     @classmethod
     def read_setup_py(cls, file: Path, raising: bool = True) -> "Dict[str, Any]":
 
-        with file.open(encoding="utf-8") as f:
+        with file.open(encoding="utf-8-sig") as f:
             content = f.read()
 
         body = ast.parse(content).body


### PR DESCRIPTION
It is well known that encoding `utf-8-sig` behaves like `utf-8`, just ignoring the BOM if file has it.

fix: https://github.com/sarugaku/requirementslib/issues/364