### PR TITLE
fix: parse setup.py when file has UTF-8 BOM

### DIFF
--- a/news/364.bugfix.rst
+++ b/news/364.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an error when parsing a setup.py file that has a UTF-8 BOM.

--- a/src/requirementslib/models/setup_info.py
+++ b/src/requirementslib/models/setup_info.py
@@ -158,7 +158,7 @@ class SetupReader:
     @classmethod
     def read_setup_py(cls, file: Path, raising: bool = True) -> "Dict[str, Any]":
 
-        with file.open(encoding="utf-8") as f:
+        with file.open(encoding="utf-8-sig") as f:
             content = f.read()
 
         body = ast.parse(content).body


### PR DESCRIPTION
Fix: #364 